### PR TITLE
Add tarpaulin code coverage tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.direnv/
 result
 docs/public
+tarpaulin-*

--- a/devshell.toml
+++ b/devshell.toml
@@ -2,6 +2,7 @@
 name = "laio devshell"
 
 packages = [
+  "cargo-tarpaulin"
 ]
 
 [[commands]]
@@ -35,6 +36,12 @@ name = "clean"
 command = "cargo clean"
 help = "Run cargo clean"
 category = "rust"
+
+[[commands]]
+name = "coverage"
+command = "cargo tarpaulin --out Html"
+category = "rust"
+help = "generate code coverage"
 
 [git.hooks]
 enable = true


### PR DESCRIPTION
- Adds `cargo-tarpaulin` to the `packages` list in `devshell.toml`.
- Introduces a new `coverage` command to generate code coverage reports via `cargo tarpaulin --out Html`.