### PR TITLE
feat: add support for stopping other managed sessions

### DIFF
--- a/src/app/cli/command_line.rs
+++ b/src/app/cli/command_line.rs
@@ -53,6 +53,10 @@ enum Commands {
         /// Stop all laio managed sessions
         #[clap(short, long)]
         all: bool,
+
+        /// Stop other laio managed sessions
+        #[clap(short, long)]
+        others: bool,
     },
 
     /// List active (*) and available sessions
@@ -112,9 +116,10 @@ impl Cli {
                 muxer,
                 skip_cmds: skip_shutdown_cmds,
                 all: stop_all,
+                others: stop_other,
             } => self
                 .session(muxer)?
-                .stop(name, *skip_shutdown_cmds, *stop_all)
+                .stop(name, *skip_shutdown_cmds, *stop_all, *stop_other)
                 .wrap_err("Unable to stop session(s)!"),
             Commands::List { muxer } => {
                 let session: Vec<String> = self
@@ -177,7 +182,7 @@ impl Cli {
         if let Commands::Start { name, muxer, .. } = &self.commands {
             if let Some(n) = name {
                 log::warn!("Shutting down session: {}", n);
-                let _ = self.session(muxer).unwrap().stop(name, true, false);
+                let _ = self.session(muxer).unwrap().stop(name, true, false, false);
             } else {
                 log::warn!("No tmux session to shut down!");
             }

--- a/src/app/manager/session/manager.rs
+++ b/src/app/manager/session/manager.rs
@@ -73,9 +73,10 @@ impl SessionManager {
         name: &Option<String>,
         skip_cmds: bool,
         stop_all: bool,
+        stop_other: bool,
     ) -> Result<()> {
         self.multiplexer
-            .stop(name, skip_cmds, stop_all)
+            .stop(name, skip_cmds, stop_all, stop_other)
             .wrap_err("Multiplexer failed to stop session(s)".to_string())
     }
 

--- a/src/app/manager/session/test.rs
+++ b/src/app/manager/session/test.rs
@@ -22,14 +22,14 @@ fn session_stop() {
     // Set up expectations for `stop`
     mock_multiplexer
         .expect_stop()
-        .withf(|name, skip_cmds, stop_all| {
-            name.as_deref() == Some("foo") && !*skip_cmds && !*stop_all
+        .withf(|name, skip_cmds, stop_all, stop_other| {
+            name.as_deref() == Some("foo") && !*skip_cmds && !*stop_all && !*stop_other
         })
-        .returning(|_, _, _| Ok(()));
+        .returning(|_, _, _, _| Ok(()));
 
     let session_manager = SessionManager::new("/path/to/config", Box::new(mock_multiplexer));
 
-    let res = session_manager.stop(&Some("foo".to_string()), false, false);
+    let res = session_manager.stop(&Some("foo".to_string()), false, false, false);
     assert!(res.is_ok());
 }
 

--- a/src/common/muxer/multiplexer.rs
+++ b/src/common/muxer/multiplexer.rs
@@ -9,7 +9,13 @@ pub(crate) trait Multiplexer {
         skip_attach: bool,
         skip_cmds: bool,
     ) -> Result<()>;
-    fn stop(&self, name: &Option<String>, skip_cmds: bool, stop_all: bool) -> Result<()>;
+    fn stop(
+        &self,
+        name: &Option<String>,
+        skip_cmds: bool,
+        stop_all: bool,
+        stop_other: bool,
+    ) -> Result<()>;
     fn list_sessions(&self) -> Result<Vec<String>>;
     fn switch(&self, name: &str, skip_attach: bool) -> Result<bool>;
     fn get_session(&self) -> Result<Session>;

--- a/src/common/muxer/test.rs
+++ b/src/common/muxer/test.rs
@@ -21,6 +21,7 @@ mock! {
             name: &Option<String>,
             skip_cmds: bool,
             stop_all: bool,
+            stop_other: bool,
         ) -> Result<()>;
 
         fn list_sessions(&self) -> Result<Vec<String>>;

--- a/src/muxer/tmux/test.rs
+++ b/src/muxer/tmux/test.rs
@@ -417,7 +417,7 @@ fn mux_stop_session() -> Result<()> {
 
     let tmux = Tmux::new_with_runner(runner);
 
-    let result = tmux.stop(&Some("valid".to_string()), false, false);
+    let result = tmux.stop(&Some("valid".to_string()), false, false, false);
 
     assert!(result.is_ok());
     Ok(())

--- a/src/muxer/zellij/mux.rs
+++ b/src/muxer/zellij/mux.rs
@@ -99,7 +99,13 @@ impl<R: Runner> Multiplexer for Zellij<R> {
         Ok(())
     }
 
-    fn stop(&self, name: &Option<String>, skip_cmds: bool, stop_all: bool) -> Result<()> {
+    fn stop(
+        &self,
+        name: &Option<String>,
+        skip_cmds: bool,
+        stop_all: bool,
+        stop_other: bool,
+    ) -> Result<()> {
         let current_session_name = self.client.current_session_name()?;
         log::debug!("Current session name: {}", current_session_name);
 
@@ -111,7 +117,7 @@ impl<R: Runner> Multiplexer for Zellij<R> {
             bail!("Stopping all and specifying a session name are mutually exclusive.")
         };
 
-        if stop_all {
+        if stop_all || stop_other {
             log::trace!("Closing all laio sessions.");
             for name in self.list_sessions()?.into_iter() {
                 if name == current_session_name {
@@ -121,7 +127,7 @@ impl<R: Runner> Multiplexer for Zellij<R> {
 
                 if self.is_laio_session(&name)? {
                     log::debug!("Closing session: {:?}", name);
-                    self.stop(&Some(name.to_string()), skip_cmds, false)?;
+                    self.stop(&Some(name.to_string()), skip_cmds, false, false)?;
                 }
             }
             if !self.client.is_inside_session() {

--- a/src/muxer/zellij/test.rs
+++ b/src/muxer/zellij/test.rs
@@ -128,7 +128,7 @@ fn mux_stop_session() -> Result<()> {
 
     let zellij = Zellij::new_with_runner(runner);
 
-    let _result = zellij.stop(&Some("valid".to_string()), false, false)?;
+    let _result = zellij.stop(&Some("valid".to_string()), false, false, false)?;
 
     Ok(())
 }


### PR DESCRIPTION
- Introduce stop_other flag to CLI, session manager, and multiplexer interfaces
- Update Tmux and Zellij multiplexer implementations to handle stop_other logic
- Adjust session stopping logic to prevent mutually exclusive use of stop_all/stop_other with session name
- Refactor tests and mock implementations to accommodate new stop_other parameter