### PR TITLE
refactor: remove tempfile and tmpfile dependencies and update temp di…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/flake-checker-action@main
 
-      - run: nix develop --command tests
+      - run: nix build .#laio-x86_64-linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,12 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,18 +414,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -558,8 +540,6 @@ dependencies = [
  "serde_valid",
  "serde_yaml",
  "sha2",
- "tempfile",
- "tmpfile",
 ]
 
 [[package]]
@@ -690,7 +670,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -702,7 +682,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -1199,19 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
-dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
- "rustix 1.0.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,12 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tmpfile"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70792bb5e9b3c542ef963da937f81eb674d90e1952d9f18ddb21dbaa46b78aee"
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,15 +1287,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "winapi"
@@ -1513,13 +1465,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.9.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,3 @@ sha2 = "0.10.9"
 [dev-dependencies]
 lazy_static = "1.4.0"
 mockall = "0.13.1"
-tempfile = "3.20.0"
-tmpfile = "0.0.3"

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -21,6 +21,8 @@ in
       install -m755 -D target/${config}/release/laio $out/bin/laio
     '';
 
+    RUST_BACKTRACE = 1;
+
     meta = {
       description = cargoToml.package.description;
       homepage = cargoToml.package.homepage;

--- a/src/app/manager/config/test.rs
+++ b/src/app/manager/config/test.rs
@@ -7,12 +7,11 @@ use crate::{
 };
 
 use std::{env::set_var, rc::Rc};
-use tempfile::tempdir;
 
 #[test]
-fn config_new() {
-    let temp_dir = tempdir().unwrap();
-    let temp_path = temp_dir.path().to_str().unwrap();
+fn config_create() {
+    let temp_dir = std::env::temp_dir();
+    let temp_path = temp_dir.to_str().unwrap().trim_end_matches("/");
     set_var("EDITOR", "vim");
     let mut cmd_unit = MockCmdUnitMock::new();
     let cmd_string = MockCmdStringMock::new();
@@ -51,8 +50,8 @@ fn config_new() {
 
 #[test]
 fn config_edit() {
-    let temp_dir = tempdir().unwrap();
-    let temp_path = temp_dir.path().to_str().unwrap();
+    let temp_dir = std::env::temp_dir();
+    let temp_path = temp_dir.to_str().unwrap();
     set_var("EDITOR", "vim");
     let session_name = "test";
     let mut cmd_unit = MockCmdUnitMock::new();
@@ -101,8 +100,8 @@ fn config_validate_no_windows() {
         cmd_bool,
     });
 
-    let temp_dir = tempdir().unwrap();
-    let config_path = temp_dir.path().to_str().unwrap();
+    let temp_dir = std::env::temp_dir();
+    let config_path = temp_dir.to_str().unwrap();
     let cfg = ConfigManager::new(config_path, Rc::clone(&cmd_runner));
 
     cfg.validate(&Some(session_name.to_string()), ".laio.yaml")

--- a/src/muxer/tmux/test.rs
+++ b/src/muxer/tmux/test.rs
@@ -147,8 +147,7 @@ fn mux_start_session() {
         .withf(|cmd| {
             let temp_dir = std::env::temp_dir();
             let temp_dir_str = temp_dir.to_string_lossy().trim_end_matches('/').to_string();
-            let cmd_str = cmd.to_string().replace("/tmp", &temp_dir_str);
-            cmd_str == format!("tmux new-session -d -s valid -c {temp_dir_str} -e FOO=bar")
+            cmd.to_string() == format!("tmux new-session -d -s valid -c {temp_dir_str} -e FOO=bar")
         })
         .returning(|_| Ok(()));
 


### PR DESCRIPTION
…r usage

- Remove tempfile and tmpfile from dependencies and lockfile
- Replace usage of tempfile::tempdir with std::env::temp_dir in test modules
- Update test logic to use system temp directory and adjust path handling
- Set RUST_BACKTRACE environment variable in Nix build script
- Change GitHub Actions workflow to build laio binary instead of running tests directly
- Update Cargo dependencies and lockfile to reflect removal of unused crates