### PR TITLE
feat: add stop_other condition to command execution logic

### DIFF
--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -471,7 +471,7 @@ impl<R: Runner> Multiplexer for Tmux<R> {
         }
 
         let result = (|| -> Result<()> {
-            if !skip_cmds {
+            if !skip_cmds && !stop_other {
                 match self.client.getenv(&tmux_target!(&name), LAIO_CONFIG) {
                     Ok(config) => {
                         log::trace!("Config: {config:?}");

--- a/src/muxer/zellij/mux.rs
+++ b/src/muxer/zellij/mux.rs
@@ -146,8 +146,7 @@ impl<R: Runner> Multiplexer for Zellij<R> {
         }
 
         let result = (|| -> Result<()> {
-            if !skip_cmds {
-                // checking if session is managed by laio
+            if !skip_cmds && !stop_other {
                 match self.client.getenv(&name, LAIO_CONFIG) {
                     Ok(config) => {
                         log::debug!("Config: {config:?}");


### PR DESCRIPTION
- Modify command execution guard to check both skip_cmds and stop_other flags
- Prevent command execution when stop_other flag is enabled alongside skip_cmds check