### PR TITLE
feat: add stdin support to Command struct

### DIFF
--- a/src/common/config/model/command.rs
+++ b/src/common/config/model/command.rs
@@ -10,6 +10,8 @@ pub(crate) struct Command {
     pub(crate) command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) args: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) stdin: Option<String>,
 }
 
 impl Command {
@@ -17,7 +19,7 @@ impl Command {
         let mut parts = input.split_whitespace();
         let command = parts.next().unwrap_or_default().to_string();
         let args = parts.map(|s| Value::String(s.to_string())).collect();
-        Command { command, args }
+        Command { command, args, stdin: None }
     }
 
     pub fn to_process_command(&self) -> ProcessCommand {

--- a/src/common/config/model/script.rs
+++ b/src/common/config/model/script.rs
@@ -56,6 +56,7 @@ impl Script {
         Ok(Command {
             command: self.script_to_path()?.to_string_lossy().to_string(),
             args: vec![],
+            stdin: None,
         })
     }
 }

--- a/src/muxer/zellij/model.rs
+++ b/src/muxer/zellij/model.rs
@@ -42,6 +42,7 @@ impl Command {
                     })
                 })
                 .collect::<Vec<Value>>(),
+            stdin: None,
         }
     }
 }


### PR DESCRIPTION
- Introduce optional stdin field to Command struct for input handling
- Update Command::from_str, Script::to_command, and Command::from_zellij to initialize stdin as None
- Enhance serialization logic to skip stdin when not set