### PR TITLE
feat: add tmux MCP tools for LLM communication

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,23 @@
           };
         };
 
-        packages = laioPackages;
+        packages =
+          laioPackages
+          // {
+            mcp-tools = let
+              cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+            in
+              pkgs.stdenvNoCC.mkDerivation {
+                pname = "mcp-tools";
+                version = cargoToml.package.version;
+                src = ./mcp-tools;
+
+                installPhase = ''
+                  mkdir -p $out/share/nushell/mcp-tools/tmux
+                  cp tmux.nu $out/share/nushell/mcp-tools/tmux/tmux.nu
+                '';
+              };
+          };
 
         devShells.default = pkgs.devshell.mkShell {
           packages = [toolchain];

--- a/mcp-tools/README.md
+++ b/mcp-tools/README.md
@@ -1,173 +1,60 @@
 # MCP Tools for Laio
 
-This directory contains MCP (Model Context Protocol) tools that extend functionality through the `nu-mcp` server. These tools provide specialized capabilities for managing and interrogating tmux sessions.
+MCP (Model Context Protocol) tools for extending functionality through the `nu-mcp` server.
 
-## Available Tools
+## tmux.nu
 
-### tmux.nu
-Comprehensive tmux session management and interrogation tool that provides:
+Tmux session management and interrogation tool.
 
-- **Session Management**: List all tmux sessions with detailed information
-- **Command Execution**: Send commands to specific tmux panes
-- **Content Capture**: Retrieve output from tmux panes
-- **Smart Pane Finding**: Find panes by name or context (directory, command, description)
-- **Detailed Information**: Get process information and pane details
+### Available Tools
 
-#### Key Features
+- `list_sessions` - List all tmux sessions with windows and panes
+- `send_command` - Send commands to specific panes
+- `capture_pane` - Capture content from panes
+- `get_session_info` - Get detailed session information
+- `get_pane_process` - Get process information for panes
+- `find_pane_by_name` - Find panes by exact name
+- `find_pane_by_context` - Find panes by context (directory, command, description)
+- `list_panes` - List all panes in a session
 
-- **Context-aware pane resolution**: Can find panes by contextual information like "docs pane", "build pane", etc.
-- **Nested table output**: Provides well-structured, expandable table views of session information
-- **Command logging**: All tmux commands are logged for transparency
-- **Comprehensive error handling**: Robust error messages and suggestions
+### Key Features
 
-#### Available Tools
-
-1. `list_sessions` - List all tmux sessions with windows and panes
-2. `send_command` - Send commands to specific panes
-3. `capture_pane` - Capture content from panes
-4. `get_session_info` - Get detailed session information with nested tables
-5. `get_pane_process` - Get process information for specific panes
-6. `find_pane_by_name` - Find panes by their exact name/title
-7. `find_pane_by_context` - Find panes by context (directory, command, description)
-8. `list_panes` - List all panes in a session as an organized table
+- Context-aware pane finding (e.g., "docs", "build")
+- Structured table output
+- Command logging
 
 ## Installation
 
-### Using Nix (Recommended)
-
-Install the mcp-tools package:
-
+### Nix
 ```bash
 nix profile install .#mcp-tools
 ```
 
-This will install the tools to `~/.nix-profile/share/nushell/mcp-tools/tmux/tmux.nu`.
+Installs to `~/.nix-profile/share/nushell/mcp-tools/tmux/tmux.nu`
 
-For building only (without installing):
+### Manual
+Copy `tmux.nu` to your nu-mcp tools directory.
 
-```bash
-nix build .#mcp-tools
-```
+## Usage
 
-### Manual Installation
-
-Copy the `.nu` files to your nu-mcp tools directory:
-
-```bash
-cp mcp-tools/*.nu /path/to/your/nu-mcp/tools/
-```
-
-## Usage with nu-mcp
-
-### Configuration
-
-Configure your MCP client to use nu-mcp with the tools directory:
+Configure nu-mcp:
 
 ```yaml
 nu-mcp-tmux:
   command: "nu-mcp"
   args:
-    - "--tools-dir=~/.nix-profile/share/nushell/mcp-tools/tmux"
+    - "--tools-dir"
+    - "~/.nix-profile/share/nushell/mcp-tools/tmux"
 ```
 
-Or if you installed manually:
-
-```yaml
-nu-mcp-tmux:
-  command: "nu-mcp"
-  args:
-    - "--tools-dir=/path/to/your/mcp-tools"
-```
-
-### Example Usage
-
-Once configured, you can use these tools through your MCP client:
-
-```javascript
-// List all tmux sessions
-await client.callTool("list_sessions", {});
-
-// Send a command to a specific pane
-await client.callTool("send_command", {
-  session: "my-session",
-  pane: "docs",  // Can use pane names or context
-  command: "ls -la"
-});
-
-// Find a pane by context
-await client.callTool("find_pane_by_context", {
-  session: "my-session", 
-  context: "docs"  // Finds panes in docs directory or with "docs" in name
-});
-
-// Capture pane content
-await client.callTool("capture_pane", {
-  session: "my-session",
-  pane: "build",
-  lines: 50
-});
-```
+Example usage via MCP client:
+- List all tmux sessions
+- Send commands to specific panes by name or context
+- Capture pane output for analysis
+- Find panes using contextual information like directory names
 
 ## Requirements
 
-- **tmux**: Must be installed and available in PATH
-- **nu-mcp**: The Nushell MCP server
-- **Nushell**: Compatible with the version used by nu-mcp
-
-## Security Notes
-
-- These tools execute tmux commands with the same privileges as the nu-mcp server
-- Be cautious when using in multi-user environments
-- The tools can access any tmux session visible to the running user
-- Commands sent via `send_command` are executed in the target pane's shell environment
-
-## Development
-
-The tools follow the standard nu-mcp extension pattern:
-
-- `main list-tools` - Returns JSON array of available tools
-- `main call-tool <tool_name> <args>` - Executes the specified tool
-
-All tmux commands follow a consistent logging pattern:
-1. Build command arguments as a list
-2. Log the command with "Executing:" prefix
-3. Execute with `run-external`
-
-This pattern ensures transparency and debugging capability.
-
-## Examples
-
-### Finding the "docs" pane and sending a command
-
-```bash
-# The tool can intelligently find panes by context
-# This will find panes in directories named "docs" or with "docs" in their title
-find_pane_by_context "my-session" "docs"
-
-# Then send a command to build documentation
-send_command "my-session" "zola build" null "docs"
-```
-
-### Getting a comprehensive session overview
-
-```bash
-# Get detailed information with nested tables
-get_session_info "my-session"
-
-# Or list all panes in an organized table
-list_panes "my-session"
-```
-
-## Contributing
-
-When adding new tools:
-
-1. Follow the existing pattern in `tmux.nu`
-2. Use the `exec_tmux_command` helper for consistent logging
-3. Provide comprehensive error handling
-4. Include detailed tool descriptions and input schemas
-5. Test with various tmux configurations
-
-## Disclaimer
-
-**USE AT YOUR OWN RISK**: These tools directly interact with tmux sessions and can execute commands in terminal environments. Users are responsible for understanding the security implications and testing thoroughly before production use.
+- tmux installed and in PATH
+- nu-mcp server
+- Nushell

--- a/mcp-tools/README.md
+++ b/mcp-tools/README.md
@@ -1,0 +1,173 @@
+# MCP Tools for Laio
+
+This directory contains MCP (Model Context Protocol) tools that extend functionality through the `nu-mcp` server. These tools provide specialized capabilities for managing and interrogating tmux sessions.
+
+## Available Tools
+
+### tmux.nu
+Comprehensive tmux session management and interrogation tool that provides:
+
+- **Session Management**: List all tmux sessions with detailed information
+- **Command Execution**: Send commands to specific tmux panes
+- **Content Capture**: Retrieve output from tmux panes
+- **Smart Pane Finding**: Find panes by name or context (directory, command, description)
+- **Detailed Information**: Get process information and pane details
+
+#### Key Features
+
+- **Context-aware pane resolution**: Can find panes by contextual information like "docs pane", "build pane", etc.
+- **Nested table output**: Provides well-structured, expandable table views of session information
+- **Command logging**: All tmux commands are logged for transparency
+- **Comprehensive error handling**: Robust error messages and suggestions
+
+#### Available Tools
+
+1. `list_sessions` - List all tmux sessions with windows and panes
+2. `send_command` - Send commands to specific panes
+3. `capture_pane` - Capture content from panes
+4. `get_session_info` - Get detailed session information with nested tables
+5. `get_pane_process` - Get process information for specific panes
+6. `find_pane_by_name` - Find panes by their exact name/title
+7. `find_pane_by_context` - Find panes by context (directory, command, description)
+8. `list_panes` - List all panes in a session as an organized table
+
+## Installation
+
+### Using Nix (Recommended)
+
+Install the mcp-tools package:
+
+```bash
+nix profile install .#mcp-tools
+```
+
+This will install the tools to `~/.nix-profile/share/nushell/mcp-tools/tmux/tmux.nu`.
+
+For building only (without installing):
+
+```bash
+nix build .#mcp-tools
+```
+
+### Manual Installation
+
+Copy the `.nu` files to your nu-mcp tools directory:
+
+```bash
+cp mcp-tools/*.nu /path/to/your/nu-mcp/tools/
+```
+
+## Usage with nu-mcp
+
+### Configuration
+
+Configure your MCP client to use nu-mcp with the tools directory:
+
+```yaml
+nu-mcp-tmux:
+  command: "nu-mcp"
+  args:
+    - "--tools-dir=~/.nix-profile/share/nushell/mcp-tools/tmux"
+```
+
+Or if you installed manually:
+
+```yaml
+nu-mcp-tmux:
+  command: "nu-mcp"
+  args:
+    - "--tools-dir=/path/to/your/mcp-tools"
+```
+
+### Example Usage
+
+Once configured, you can use these tools through your MCP client:
+
+```javascript
+// List all tmux sessions
+await client.callTool("list_sessions", {});
+
+// Send a command to a specific pane
+await client.callTool("send_command", {
+  session: "my-session",
+  pane: "docs",  // Can use pane names or context
+  command: "ls -la"
+});
+
+// Find a pane by context
+await client.callTool("find_pane_by_context", {
+  session: "my-session", 
+  context: "docs"  // Finds panes in docs directory or with "docs" in name
+});
+
+// Capture pane content
+await client.callTool("capture_pane", {
+  session: "my-session",
+  pane: "build",
+  lines: 50
+});
+```
+
+## Requirements
+
+- **tmux**: Must be installed and available in PATH
+- **nu-mcp**: The Nushell MCP server
+- **Nushell**: Compatible with the version used by nu-mcp
+
+## Security Notes
+
+- These tools execute tmux commands with the same privileges as the nu-mcp server
+- Be cautious when using in multi-user environments
+- The tools can access any tmux session visible to the running user
+- Commands sent via `send_command` are executed in the target pane's shell environment
+
+## Development
+
+The tools follow the standard nu-mcp extension pattern:
+
+- `main list-tools` - Returns JSON array of available tools
+- `main call-tool <tool_name> <args>` - Executes the specified tool
+
+All tmux commands follow a consistent logging pattern:
+1. Build command arguments as a list
+2. Log the command with "Executing:" prefix
+3. Execute with `run-external`
+
+This pattern ensures transparency and debugging capability.
+
+## Examples
+
+### Finding the "docs" pane and sending a command
+
+```bash
+# The tool can intelligently find panes by context
+# This will find panes in directories named "docs" or with "docs" in their title
+find_pane_by_context "my-session" "docs"
+
+# Then send a command to build documentation
+send_command "my-session" "zola build" null "docs"
+```
+
+### Getting a comprehensive session overview
+
+```bash
+# Get detailed information with nested tables
+get_session_info "my-session"
+
+# Or list all panes in an organized table
+list_panes "my-session"
+```
+
+## Contributing
+
+When adding new tools:
+
+1. Follow the existing pattern in `tmux.nu`
+2. Use the `exec_tmux_command` helper for consistent logging
+3. Provide comprehensive error handling
+4. Include detailed tool descriptions and input schemas
+5. Test with various tmux configurations
+
+## Disclaimer
+
+**USE AT YOUR OWN RISK**: These tools directly interact with tmux sessions and can execute commands in terminal environments. Users are responsible for understanding the security implications and testing thoroughly before production use.

--- a/mcp-tools/tmux.nu
+++ b/mcp-tools/tmux.nu
@@ -1,0 +1,784 @@
+#!/usr/bin/env nu
+
+# Tmux management tool for nu-mcp - provides tmux session and pane control
+
+# Default main command
+def main [] {
+  help main
+}
+
+# List available MCP tools
+def "main list-tools" [] {
+  [
+    {
+      name: "list_sessions"
+      description: "List all tmux sessions with their windows and panes"
+      input_schema: {
+        type: "object"
+        properties: {}
+      }
+    }
+    {
+      name: "send_command"
+      description: "Send a command to a specific tmux pane"
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+          window: {
+            type: "string"
+            description: "Window name or ID (optional, defaults to current window)"
+          }
+          pane: {
+            type: "string"
+            description: "Pane ID (optional, defaults to current pane)"
+          }
+          command: {
+            type: "string"
+            description: "Command to send to the pane"
+          }
+        }
+        required: ["session", "command"]
+      }
+    }
+    {
+      name: "capture_pane"
+      description: "Capture and return the content of a specific tmux pane"
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+          window: {
+            type: "string"
+            description: "Window name or ID (optional, defaults to current window)"
+          }
+          pane: {
+            type: "string"
+            description: "Pane ID (optional, defaults to current pane)"
+          }
+          lines: {
+            type: "integer"
+            description: "Number of lines to capture (optional, defaults to all visible)"
+          }
+        }
+        required: ["session"]
+      }
+    }
+    {
+      name: "get_session_info"
+      description: "Get detailed information about a specific tmux session"
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+        }
+        required: ["session"]
+      }
+    }
+    {
+      name: "get_pane_process"
+      description: "Get information about the running process in a specific tmux pane"
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+          window: {
+            type: "string"
+            description: "Window name or ID (optional, defaults to current window)"
+          }
+          pane: {
+            type: "string"
+            description: "Pane ID (optional, defaults to current pane)"
+          }
+        }
+        required: ["session"]
+      }
+    }
+    {
+      name: "find_pane_by_name"
+      description: "Find a pane by its name across all windows in a session"
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+          pane_name: {
+            type: "string"
+            description: "Name of the pane to find"
+          }
+        }
+        required: ["session", "pane_name"]
+      }
+    }
+    {
+      name: "find_pane_by_context"
+      description: "Find a pane by context like directory path, command, or description. Useful for finding 'docs pane', 'build pane', etc."
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+          context: {
+            type: "string"
+            description: "Context to search for: directory name (e.g. 'docs'), command (e.g. 'zola'), or description"
+          }
+        }
+        required: ["session", "context"]
+      }
+    }
+    {
+      name: "list_panes"
+      description: "List all panes in a session as a clear table showing window, pane, name, process, directory, and status"
+      input_schema: {
+        type: "object"
+        properties: {
+          session: {
+            type: "string"
+            description: "Session name or ID"
+          }
+        }
+        required: ["session"]
+      }
+    }
+  ] | to json
+}
+
+# Call a specific tool with arguments
+def "main call-tool" [
+  tool_name: string # Name of the tool to call
+  args: any = {} # JSON arguments for the tool
+] {
+  let parsed_args = if ($args | describe) == "string" { 
+    $args | from json 
+  } else { 
+    $args 
+  }
+
+  match $tool_name {
+    "list_sessions" => {
+      list_sessions
+    }
+    "send_command" => {
+      let session = $parsed_args | get session
+      let command = $parsed_args | get command
+      let window = if "window" in $parsed_args { $parsed_args | get window } else { null }
+      let pane = if "pane" in $parsed_args { $parsed_args | get pane } else { null }
+      send_command $session $command $window $pane
+    }
+    "capture_pane" => {
+      let session = $parsed_args | get session
+      let window = if "window" in $parsed_args { $parsed_args | get window } else { null }
+      let pane = if "pane" in $parsed_args { $parsed_args | get pane } else { null }
+      let lines = if "lines" in $parsed_args { $parsed_args | get lines } else { null }
+      capture_pane $session $window $pane $lines
+    }
+    "get_session_info" => {
+      let session = $parsed_args | get session
+      get_session_info $session
+    }
+    "get_pane_process" => {
+      let session = $parsed_args | get session
+      let window = if "window" in $parsed_args { $parsed_args | get window } else { null }
+      let pane = if "pane" in $parsed_args { $parsed_args | get pane } else { null }
+      get_pane_process $session $window $pane
+    }
+    "find_pane_by_name" => {
+      let session = $parsed_args | get session
+      let pane_name = $parsed_args | get pane_name
+      find_pane_by_name $session $pane_name
+    }
+    "find_pane_by_context" => {
+      let session = $parsed_args | get session
+      let context = $parsed_args | get context
+      find_pane_by_context $session $context
+    }
+    "list_panes" => {
+      let session = $parsed_args | get session
+      list_panes $session
+    }
+    _ => {
+      error make {msg: $"Unknown tool: ($tool_name)"}
+    }
+  }
+}
+
+# Check if tmux is available
+def check_tmux [] {
+  try {
+    tmux -V | str trim
+    true
+  } catch {
+    false
+  }
+}
+
+# Helper function to execute tmux commands with logging (following k8s pattern)
+def exec_tmux_command [cmd_args: list<string>] {
+  let full_cmd = (["tmux"] | append $cmd_args)
+  print $"Executing: ($full_cmd | str join ' ')"
+  run-external ...$full_cmd
+}
+
+# List all tmux sessions with their windows and panes
+def list_sessions [] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Get sessions
+    let cmd_args = ["list-sessions" "-F" "#{session_name}|#{session_created}|#{session_attached}|#{session_windows}"]
+    let sessions = exec_tmux_command $cmd_args | lines
+    
+    if ($sessions | length) == 0 {
+      return "No tmux sessions found"
+    }
+
+    mut output = ["Tmux Sessions:"]
+    
+    for session_line in $sessions {
+      let parts = $session_line | split row "|"
+      let session_name = $parts | get 0
+      let created = $parts | get 1
+      let attached = $parts | get 2
+      let window_count = $parts | get 3
+      
+      let status = if $attached == "1" { "attached" } else { "detached" }
+      $output = ($output | append $"  Session: ($session_name) \(($status), ($window_count) windows\)")
+      
+      # Get windows for this session
+      let cmd_args = ["list-windows" "-t" $session_name "-F" "#{window_index}|#{window_name}|#{window_panes}"]
+      let windows = exec_tmux_command $cmd_args | lines
+      
+      for window_line in $windows {
+        let window_parts = $window_line | split row "|"
+        let window_index = $window_parts | get 0
+        let window_name = $window_parts | get 1
+        let pane_count = $window_parts | get 2
+        
+        $output = ($output | append $"    Window ($window_index): ($window_name) \(($pane_count) panes\)")
+        
+        # Get panes for this window
+        let cmd_args = ["list-panes" "-t" $"($session_name):($window_index)" "-F" "#{pane_index}|#{pane_current_command}|#{pane_active}|#{pane_title}"]
+        let panes = exec_tmux_command $cmd_args | lines
+        
+        for pane_line in $panes {
+          let pane_parts = $pane_line | split row "|"
+          let pane_index = $pane_parts | get 0
+          let current_command = $pane_parts | get 1
+          let is_active = $pane_parts | get 2
+          let pane_title = $pane_parts | get 3
+          
+          let active_marker = if $is_active == "1" { " \(active\)" } else { "" }
+          let title_display = if $pane_title != "" { $" \"($pane_title)\"" } else { "" }
+          $output = ($output | append $"      Pane ($pane_index): ($current_command)($title_display)($active_marker)")
+        }
+      }
+    }
+    
+    $output | str join (char newline)
+  } catch {
+    "Error: Failed to list tmux sessions. Make sure tmux is running."
+  }
+}
+
+# Send a command to a specific tmux pane
+def send_command [session: string, command: string, window?: string, pane?: string] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Resolve the target (supports pane names)
+    let target = resolve_pane_target $session $window $pane
+    if $target == null {
+      return $"Error: Could not find pane '($pane)' in session '($session)'"
+    }
+    
+    # Send the command
+    let cmd_args = ["send-keys" "-t" $target $command "Enter"]
+    exec_tmux_command $cmd_args
+    $"Command sent to ($target): ($command)"
+  } catch {
+    $"Error: Failed to send command to tmux session/pane. Check that the session '($session)' exists."
+  }
+}
+
+# Capture content from a specific tmux pane
+def capture_pane [session: string, window?: string, pane?: string, lines?: int] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Resolve the target (supports pane names)
+    let target = resolve_pane_target $session $window $pane
+    if $target == null {
+      return $"Error: Could not find pane '($pane)' in session '($session)'"
+    }
+    
+    # Build capture command
+    mut cmd_args = ["capture-pane" "-t" $target "-p"]
+    if $lines != null {
+      $cmd_args = ($cmd_args | append ["-S" $"-($lines)"])
+    }
+    
+    # Capture the pane content
+    let content = exec_tmux_command $cmd_args | str trim
+    
+    $"Pane content from ($target):\n---\n($content)\n---"
+  } catch {
+    $"Error: Failed to capture pane content. Check that the session/pane '($session)' exists."
+  }
+}
+
+# Get detailed information about a specific tmux session
+def get_session_info [session: string] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Get session info
+    let cmd_args = ["display-message" "-t" $session "-p" "#{session_name}|#{session_created}|#{session_attached}|#{session_windows}|#{session_group}|#{session_id}"]
+    let session_info = exec_tmux_command $cmd_args | str trim
+    let parts = $session_info | split row "|"
+    
+    let session_name = $parts | get 0
+    let created_timestamp = $parts | get 1
+    let attached = $parts | get 2
+    let window_count = $parts | get 3
+    let session_group = $parts | get 4
+    let session_id = $parts | get 5
+    
+    let status = if $attached == "1" { "attached" } else { "detached" }
+    let created_date = $created_timestamp | into int | into datetime
+    
+    mut output = [
+      $"Session Information for: ($session_name)"
+      $"Session ID: ($session_id)"
+      $"Status: ($status)"
+      $"Created: ($created_date)"
+      $"Windows: ($window_count)"
+    ]
+    
+    if $session_group != "" {
+      $output = ($output | append $"Group: ($session_group)")
+    }
+    
+    $output = ($output | append "")
+    
+    # Get all panes across all windows as a table
+    let cmd_args = ["list-windows" "-t" $session "-F" "#{window_index}|#{window_name}|#{window_active}"]
+    let windows = exec_tmux_command $cmd_args | lines
+    
+    mut all_panes = []
+    
+    for window_line in $windows {
+      let window_parts = $window_line | split row "|"
+      let window_index = $window_parts | get 0
+      let window_name = $window_parts | get 1
+      let window_is_active = $window_parts | get 2
+      
+      # Get detailed pane information for this window
+      let cmd_args = ["list-panes" "-t" $"($session):($window_index)" "-F" "#{pane_index}|#{pane_title}|#{pane_current_command}|#{pane_active}|#{pane_current_path}|#{pane_pid}"]
+      let panes = exec_tmux_command $cmd_args | lines
+      
+      for pane_line in $panes {
+        let pane_parts = $pane_line | split row "|"
+        let pane_index = $pane_parts | get 0
+        let pane_title = $pane_parts | get 1
+        let current_command = $pane_parts | get 2
+        let pane_is_active = $pane_parts | get 3
+        let current_path = $pane_parts | get 4
+        let pane_pid = $pane_parts | get 5
+        
+        # Determine custom name vs auto-generated title
+        let looks_auto_generated = (
+          ($pane_title | str contains "> ") or
+          ($pane_title | str contains "✳") or
+          ($pane_title | str contains "/") or
+          ($pane_title == $current_path) or
+          ($pane_title == "")
+        )
+        
+        let custom_name = if $looks_auto_generated or ($pane_title | str length) > 20 { 
+          "" 
+        } else { 
+          $pane_title 
+        }
+        
+        let status = if $window_is_active == "1" and $pane_is_active == "1" { 
+          "active" 
+        } else if $pane_is_active == "1" { 
+          "current" 
+        } else { 
+          "inactive" 
+        }
+        
+        let pane_record = {
+          window: $window_index
+          window_name: $window_name
+          pane: $pane_index
+          name: $custom_name
+          process: $current_command
+          directory: ($current_path | path basename)
+          full_path: $current_path
+          pid: $pane_pid
+          status: $status
+          target: $"($session):($window_index).($pane_index)"
+        }
+        
+        $all_panes = ($all_panes | append $pane_record)
+      }
+    }
+    
+    # Create expanded nested table structure
+    $output = ($output | append "Windows and Panes:")
+    $output = ($output | append "")
+    
+    # Use group-by to create proper nested table with expansion
+    let nested_table = $all_panes | 
+      select window window_name pane process directory status | 
+      group-by window window_name --to-table |
+      update items {|row| $row.items | select pane process directory status }
+    
+    let table_output = $nested_table | table --expand
+    $output = ($output | append $table_output)
+    
+    $output | str join (char newline)
+  } catch {
+    $"Error: Failed to get session info for '($session)'. Check that the session exists."
+  }
+}
+
+# Helper function to resolve pane target (supports pane names and context)
+def resolve_pane_target [session: string, window?: string, pane?: string] {
+  # If pane looks like a name (not just numbers), try to find it by name or context
+  if $pane != null and not ($pane =~ '^[0-9]+$') {
+    # First try finding by explicit name
+    let find_result = find_pane_by_name $session $pane
+    if ($find_result | str starts-with "Found pane") {
+      # Extract target from the result
+      let target_line = $find_result | lines | where ($it | str starts-with "Target:") | first
+      let target = $target_line | str replace "Target: " ""
+      return $target
+    }
+    
+    # If name search failed, try context search
+    let context_result = find_pane_by_context $session $pane
+    if ($context_result | str starts-with "Found pane") {
+      # Extract target from the result
+      let target_line = $context_result | lines | where ($it | str starts-with "Target:") | first
+      let target = $target_line | str replace "Target: " ""
+      return $target
+    }
+    
+    return null
+  }
+  
+  # Build target using window/pane IDs
+  mut target = $session
+  if $window != null {
+    $target = $"($target):($window)"
+  }
+  if $pane != null {
+    if $window == null {
+      $target = $"($target):"
+    }
+    $target = $"($target).($pane)"
+  }
+  return $target
+}
+
+# Get information about the running process in a specific tmux pane
+def get_pane_process [session: string, window?: string, pane?: string] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Resolve the target (supports pane names)
+    let target = resolve_pane_target $session $window $pane
+    if $target == null {
+      return $"Error: Could not find pane '($pane)' in session '($session)'"
+    }
+    
+    # Get pane information including PID and command
+    let cmd_args = ["display-message" "-t" $target "-p" "#{pane_index}|#{pane_current_command}|#{pane_pid}|#{pane_current_path}|#{pane_width}x#{pane_height}|#{pane_active}"]
+    let pane_info = exec_tmux_command $cmd_args | str trim
+    let parts = $pane_info | split row "|"
+    
+    let pane_index = $parts | get 0
+    let current_command = $parts | get 1
+    let pane_pid = $parts | get 2
+    let current_path = $parts | get 3
+    let pane_size = $parts | get 4
+    let is_active = $parts | get 5
+    
+    let active_status = if $is_active == "1" { "active" } else { "inactive" }
+    
+    # Try to get more detailed process information
+    let process_info = try {
+      run-external "ps" "-p" $pane_pid "-o" "pid,ppid,command" | lines | skip 1 | first
+    } catch {
+      $"PID ($pane_pid): ($current_command)"
+    }
+    
+    $"Pane Process Information for ($target):
+Pane Index: ($pane_index)
+Status: ($active_status)
+Size: ($pane_size)
+Current Path: ($current_path)
+Current Command: ($current_command)
+Process ID: ($pane_pid)
+Process Details: ($process_info)"
+  } catch {
+    $"Error: Failed to get pane process info for '($session)'. Check that the session/pane exists."
+  }
+}
+
+# Find a pane by its name/title across all windows in a session
+def find_pane_by_name [session: string, pane_name: string] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Get all windows in the session
+    let cmd_args = ["list-windows" "-t" $session "-F" "#{window_index}"]
+    let windows = exec_tmux_command $cmd_args | lines
+    
+    mut found_panes = []
+    
+    for window_index in $windows {
+      # Get panes in this window with their titles
+      let cmd_args = ["list-panes" "-t" $"($session):($window_index)" "-F" "#{pane_index}|#{pane_title}|#{pane_current_command}|#{pane_active}|#{pane_current_path}"]
+      let panes = exec_tmux_command $cmd_args | lines
+      
+      for pane_line in $panes {
+        let parts = $pane_line | split row "|"
+        let pane_index = $parts | get 0
+        let pane_title = $parts | get 1
+        let current_command = $parts | get 2
+        let is_active = $parts | get 3
+        let current_path = $parts | get 4
+        
+        # Check if this pane matches the name (case-insensitive)
+        if ($pane_title | str downcase) == ($pane_name | str downcase) {
+          let active_status = if $is_active == "1" { "active" } else { "inactive" }
+          let pane_info = {
+            session: $session
+            window: $window_index
+            pane: $pane_index
+            title: $pane_title
+            command: $current_command
+            status: $active_status
+            path: $current_path
+            target: $"($session):($window_index).($pane_index)"
+          }
+          $found_panes = ($found_panes | append $pane_info)
+        }
+      }
+    }
+    
+    if ($found_panes | length) == 0 {
+      $"No pane named '($pane_name)' found in session '($session)'"
+    } else if ($found_panes | length) == 1 {
+      let pane = $found_panes | first
+      $"Found pane '($pane_name)' in session ($session):
+Target: ($pane.target)
+Window: ($pane.window), Pane: ($pane.pane)
+Status: ($pane.status)
+Command: ($pane.command)
+Path: ($pane.path)"
+    } else {
+      mut output = [$"Found ($found_panes | length) panes named '($pane_name)' in session ($session):"]
+      for pane in $found_panes {
+        $output = ($output | append $"  Target: ($pane.target) - ($pane.command) \(($pane.status)\)")
+      }
+      $output | str join (char newline)
+    }
+  } catch {
+    $"Error: Failed to search for pane '($pane_name)' in session '($session)'. Check that the session exists."
+  }
+}
+
+# Find a pane by context (directory, command, description)
+def find_pane_by_context [session: string, context: string] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Get all windows in the session
+    let cmd_args = ["list-windows" "-t" $session "-F" "#{window_index}"]
+    let windows = exec_tmux_command $cmd_args | lines
+    
+    mut found_panes = []
+    let search_context = $context | str downcase
+    
+    for window_index in $windows {
+      # Get panes in this window with detailed info
+      let cmd_args = ["list-panes" "-t" $"($session):($window_index)" "-F" "#{pane_index}|#{pane_title}|#{pane_current_command}|#{pane_active}|#{pane_current_path}"]
+      let panes = exec_tmux_command $cmd_args | lines
+      
+      for pane_line in $panes {
+        let parts = $pane_line | split row "|"
+        let pane_index = $parts | get 0
+        let pane_title = $parts | get 1
+        let current_command = $parts | get 2
+        let is_active = $parts | get 3
+        let current_path = $parts | get 4
+        
+        # Check if context matches any of: title, command, path segment, or directory name
+        let title_lower = $pane_title | str downcase
+        let command_lower = $current_command | str downcase
+        let path_lower = $current_path | str downcase
+        let dir_name = $current_path | path basename | str downcase
+        
+        let matches = (
+          ($title_lower | str contains $search_context) or
+          ($command_lower | str contains $search_context) or
+          ($path_lower | str contains $search_context) or
+          ($dir_name == $search_context)
+        )
+        
+        if $matches {
+          let active_status = if $is_active == "1" { "active" } else { "inactive" }
+          let pane_info = {
+            session: $session
+            window: $window_index
+            pane: $pane_index
+            title: $pane_title
+            command: $current_command
+            status: $active_status
+            path: $current_path
+            target: $"($session):($window_index).($pane_index)"
+          }
+          $found_panes = ($found_panes | append $pane_info)
+        }
+      }
+    }
+    
+    if ($found_panes | length) == 0 {
+      $"No pane matching context '($context)' found in session '($session)'"
+    } else if ($found_panes | length) == 1 {
+      let pane = $found_panes | first
+      $"Found pane matching context '($context)' in session ($session):
+Target: ($pane.target)
+Window: ($pane.window), Pane: ($pane.pane)
+Status: ($pane.status)
+Command: ($pane.command)
+Path: ($pane.path)
+Title: ($pane.title)"
+    } else {
+      mut output = [$"Found ($found_panes | length) panes matching context '($context)' in session ($session):"]
+      for pane in $found_panes {
+        $output = ($output | append $"  Target: ($pane.target) - ($pane.command) in ($pane.path | path basename) \(($pane.status)\)")
+      }
+      $output | str join (char newline)
+    }
+  } catch {
+    $"Error: Failed to search for context '($context)' in session '($session)'. Check that the session exists."
+  }
+}
+
+# List all panes in a session as a table
+def list_panes [session: string] {
+  if not (check_tmux) {
+    return "Error: tmux is not installed or not available in PATH"
+  }
+
+  try {
+    # Get all windows
+    let cmd_args = ["list-windows" "-t" $session "-F" "#{window_index}|#{window_name}|#{window_active}"]
+    let windows = exec_tmux_command $cmd_args | lines
+    
+    mut all_panes = []
+    
+    for window_line in $windows {
+      let window_parts = $window_line | split row "|"
+      let window_index = $window_parts | get 0
+      let window_name = $window_parts | get 1
+      let window_is_active = $window_parts | get 2
+      
+      # Get detailed pane information for this window
+      let cmd_args = ["list-panes" "-t" $"($session):($window_index)" "-F" "#{pane_index}|#{pane_title}|#{pane_current_command}|#{pane_active}|#{pane_current_path}|#{pane_pid}"]
+      let panes = exec_tmux_command $cmd_args | lines
+      
+      for pane_line in $panes {
+        let pane_parts = $pane_line | split row "|"
+        let pane_index = $pane_parts | get 0
+        let pane_title = $pane_parts | get 1
+        let current_command = $pane_parts | get 2
+        let pane_is_active = $pane_parts | get 3
+        let current_path = $pane_parts | get 4
+        let pane_pid = $pane_parts | get 5
+        
+        # Determine custom name vs auto-generated title
+        let looks_auto_generated = (
+          ($pane_title | str contains "> ") or
+          ($pane_title | str contains "✳") or
+          ($pane_title | str contains "/") or
+          ($pane_title == $current_path) or
+          ($pane_title == "")
+        )
+        
+        let custom_name = if $looks_auto_generated or ($pane_title | str length) > 20 { 
+          "" 
+        } else { 
+          $pane_title 
+        }
+        
+        let status = if $window_is_active == "1" and $pane_is_active == "1" { 
+          "active" 
+        } else if $pane_is_active == "1" { 
+          "current" 
+        } else { 
+          "inactive" 
+        }
+        
+        let pane_record = {
+          window: $window_index
+          window_name: $window_name
+          pane: $pane_index
+          name: $custom_name
+          process: $current_command
+          directory: ($current_path | path basename)
+          full_path: $current_path
+          pid: $pane_pid
+          status: $status
+          target: $"($session):($window_index).($pane_index)"
+        }
+        
+        $all_panes = ($all_panes | append $pane_record)
+      }
+    }
+    
+    # Create proper nested table structure with expansion
+    $all_panes | 
+      select window window_name pane process directory status | 
+      group-by window window_name --to-table |
+      update items {|row| $row.items | select pane process directory status } |
+      table --expand
+  } catch {
+    $"Error: Failed to list panes for session '($session)'. Check that the session exists."
+  }
+}


### PR DESCRIPTION
## Summary
- Add tmux MCP tools that allow LLMs to communicate with and execute commands in tmux sessions
- Nix package for easy installation 
- Documentation with usage examples

## Changes
- **tmux.nu**: Helpful MCP tools for LLM-tmux interaction
  - List sessions, windows, and panes in tabular format
  - Send commands to specific panes  
  - Capture pane content for analysis
  - Find panes by name or context (e.g., "docs", "build")
  - Get process information from panes

- **Nix package**: mcp-tools derivation for easy installation
  - Installs to share/nushell/mcp-tools/tmux/
  - Version synced with Cargo.toml

- **Documentation**: Concise README with installation and usage
  - Installation instructions for Nix and manual setup
  - Configuration examples for nu-mcp integration

## Features
- Tabular data hints in tool descriptions for proper LLM display
- Context-aware pane finding for intuitive usage
- Command logging following k8s-tools pattern
- Structured output for informational commands, raw text for content

## Scope
These are utility tools for LLM communication with tmux, not a full tmux session manager. The tools provide essential commands for:
- Discovering what's running in a tmux session
- Sending commands to specific panes
- Retrieving output for analysis
- Finding panes by contextual information

## Test plan
- [x] Verify tmux.nu implements all MCP tools correctly
- [x] Test tabular data output formatting
- [x] Confirm command logging follows k8s pattern consistently
- [x] Validate Nix derivation builds and installs to correct path
- [x] Test context-based pane finding functionality