### PR TITLE
refactor: rename mcp-tools package to tmux-mcp-tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
         packages =
           laioPackages
           // {
-            mcp-tools = let
+            tmux-mcp-tools = let
               cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
             in
               pkgs.stdenvNoCC.mkDerivation {


### PR DESCRIPTION
- Rename package key from mcp-tools to tmux-mcp-tools in flake output
- Update package reference to align with new naming convention