### PR TITLE
Fix cross-compilation error: use native ARM64 runner for Linux builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
             nix_system: x86_64-linux
           - os: macos-14
             nix_system: aarch64-darwin
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             nix_system: aarch64-linux
     steps:
       - name: Checkout release branch


### PR DESCRIPTION
## Summary
- Updates release workflow to use `ubuntu-24.04-arm` for aarch64-linux builds
- Resolves cross-compilation "Exec format error" with backtrace-ext dependency
- Uses GitHub's native ARM64 runners (GA since August 2025)

## Problem
GitHub Actions was failing with cross-compilation errors when building aarch64-linux targets:
```
error: executing '/nix/store/.../bash': Exec format error
```

The issue was that we were using `ubuntu-latest` (x86_64) runners to build aarch64-linux targets via cross-compilation, which fails with certain dependencies like backtrace-ext.

## Solution
Changed the workflow to use native ARM64 runners for each target:
- `ubuntu-latest` → x86_64-linux (native)
- `macos-14` → aarch64-darwin (native) 
- `ubuntu-24.04-arm` → aarch64-linux (native) ← **Fixed**

## Test Plan
- [x] Docker test confirms native aarch64-linux builds work perfectly
- [ ] Verify GitHub Actions workflow succeeds with native ARM64 runner
- [ ] Confirm all three platforms build successfully

## Additional Context
This uses GitHub's latest ARM64 Linux runners which became GA in August 2025 and are free for public repositories.