### PR TITLE
fix: replace hardcoded SHA256 hashes with dynamic patterns in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,9 +131,9 @@ jobs:
             | str replace -r 'laio-[0-9]+\.[0-9]+\.[0-9]+-aarch64-darwin\.tgz' $'laio-($version)-aarch64-darwin.tgz'
             | str replace -r 'laio-[0-9]+\.[0-9]+\.[0-9]+-aarch64-linux\.tgz' $'laio-($version)-aarch64-linux.tgz'
             | str replace -r 'laio-[0-9]+\.[0-9]+\.[0-9]+-x86_64-linux\.tgz' $'laio-($version)-x86_64-linux.tgz'
-            | str replace -r 'sha256 "33643d682abd23761c84b6c3bc9ab4a1f026a401c68c6f3db1a812b74750d977"' $'sha256 "($aarch64_darwin_hash)"'
-            | str replace -r 'sha256 "50706fc5a04fb8ff85c8bc0d2f9c0d21d6233a8b9a051a01a61e25b6708313d6"' $'sha256 "($aarch64_linux_hash)"'
-            | str replace -r 'sha256 "b7302dd5c42250474923230771239276471d47888516e40e1320650befcb69a9"' $'sha256 "($x86_64_linux_hash)"'
+             | str replace -r 'aarch64-darwin\.tgz"\s+sha256 "[a-f0-9]{64}"' $'aarch64-darwin.tgz"\n      sha256 "($aarch64_darwin_hash)"'
+             | str replace -r 'x86_64-linux\.tgz"\s+sha256 "[a-f0-9]{64}"' $'x86_64-linux.tgz"\n      sha256 "($x86_64_linux_hash)"'
+             | str replace -r 'aarch64-linux\.tgz"\s+sha256 "[a-f0-9]{64}"' $'aarch64-linux.tgz"\n      sha256 "($aarch64_linux_hash)"'
           )
           $updated_formula | save --force Formula/laio.rb
           git add Formula/laio.rb


### PR DESCRIPTION
## Summary

Fixes a critical bug in the release workflow that would cause Homebrew formula updates to fail silently after the first release.

## Problem

The workflow was using hardcoded SHA256 hash values in regex patterns to update the Homebrew formula:

```nushell
| str replace -r 'sha256 "33643d682abd23761c84b6c3bc9ab4a1f026a401c68c6f3db1a812b74750d977"' ...
```

This would only work for the first release. After any release, the SHA256 hashes in the formula would change, and these hardcoded patterns would no longer match, causing silent failures.

## Solution

Replace hardcoded hash patterns with context-aware dynamic patterns that match any valid SHA256 hash based on platform context:

```nushell
| str replace -r 'aarch64-darwin\.tgz"\s+sha256 "[a-f0-9]{64}"' ...
| str replace -r 'x86_64-linux\.tgz"\s+sha256 "[a-f0-9]{64}"' ...
| str replace -r 'aarch64-linux\.tgz"\s+sha256 "[a-f0-9]{64}"' ...
```

## Benefits

- ✅ Works for all future releases, not just the first one
- ✅ Matches any valid 64-character hex SHA256 hash
- ✅ Uses platform context (filename) to identify correct hash to replace
- ✅ Maintains proper indentation and formatting in formula
- ✅ No more silent failures in Homebrew formula updates

## Testing

Verified that:
- Current SHA256 hashes are 64 hex characters and match the pattern `[a-f0-9]{64}`
- Pattern correctly identifies platform-specific hashes using filename context
- Replacement maintains proper Ruby formatting for Homebrew formula