### PR TITLE
feat: docs: add usage instructions for listing and managing configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ windows:
       - flex: 1
 ```
 
+### Listing and Managing
+
+List sessions and configurations with `laio list` or `laio config list`. Both support `--json` for JSON output.
+
+Edit, validate, or delete configurations with `laio config edit|validate|delete <name>`.
+
 ### Completion
 
 To generate the right shell completion for your shell run `laio completion <your-shell>`.

--- a/docs/content/docs/getting-started/advanced.md
+++ b/docs/content/docs/getting-started/advanced.md
@@ -55,3 +55,20 @@ you can also use laio to create a config file from within the tmux session you a
 laio session yaml > ~/.config/laio/<name>.yaml
 ```
 This will serialise the current tmux session into the right format and into the file specified.
+
+## Managing Configurations
+
+Edit a configuration:
+```bash
+laio config edit <name>
+```
+
+Validate a configuration:
+```bash
+laio config validate <name>
+```
+
+Delete a configuration:
+```bash
+laio config delete <name>
+```

--- a/docs/content/docs/getting-started/basics.md
+++ b/docs/content/docs/getting-started/basics.md
@@ -131,6 +131,20 @@ windows:
       - flex: 1
 ```
 
+## Listing Sessions and Configurations
+
+List active (*) and available sessions:
+```bash
+laio list
+```
+
+List all configurations:
+```bash
+laio config list
+```
+
+Both commands support `--json` or `-j` flag for JSON output.
+
 ## Completion
 
 To generate the right shell completion for your shell run


### PR DESCRIPTION
This PR updates documentation to include clear instructions for listing, editing, validating, and deleting configurations, as well as listing sessions, using the `laio` CLI.

## Details
- Added sections to `README.md`, `basics.md`, and `advanced.md` describing how to use `laio list`, `laio config list`, and related commands.
- Documented support for JSON output via `--json` or `-j` flags.
- Provided usage examples for editing, validating, and deleting configurations with `laio config edit|validate|delete <name>`.
- Ensured instructions are present in both basic and advanced getting started guides for user clarity.

## Context
These changes improve onboarding and usability by making configuration and session management features more discoverable and easier to use for new and existing users.