### PR TITLE
docs: Improve website title and SEO metadata

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -2,6 +2,7 @@
 base_url = "https://laio.sh"
 
 title = 'laio'
+description = 'Flexbox-inspired layout and session manager for tmux'
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
@@ -21,6 +22,10 @@ author = "Christian Kemper"
 github = "https://github.com/ck3mp3r"
 email = "christian.kemper@pm.me"
 is_netlify = false
+
+# SEO and meta
+title_separator = "|"
+title_addition = "Flexbox-inspired layout and session manager for tmux"
 
 [extra.footer]
 info = ' '


### PR DESCRIPTION
## Overview

Updates the website configuration to provide more descriptive titles and better SEO metadata.

## Changes

**File:** `docs/config.toml`

### Added Fields

1. **description** - Site-wide description for SEO
   - Value: 'Flexbox-inspired layout and session manager for tmux'
   - Used in meta tags and search engine results

2. **title_separator** - Separator between page name and site title
   - Value: '|'
   - Provides consistent formatting across all pages

3. **title_addition** - Descriptive addition to page titles
   - Value: 'Flexbox-inspired layout and session manager for tmux'
   - Appended to page names for context

## Impact

### Before
- Page titles: Just the page name (e.g., "Quick Start")
- Limited SEO metadata
- No site description

### After
- Page titles: "Quick Start | Flexbox-inspired layout and session manager for tmux"
- Enhanced SEO with description field
- Clearer context for users with multiple tabs open
- Better search engine visibility

## Benefits

- **Improved SEO** - Search engines get better context about the site
- **Better UX** - Users can identify tabs more easily
- **Professional appearance** - Consistent, descriptive page titles
- **Discoverability** - More informative search results

## Testing

- [x] Configuration syntax is valid
- [x] No breaking changes to existing pages
- [x] Title formatting follows theme conventions