### PR TITLE
fix: update zola syntax highlighting config to new format

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -13,9 +13,9 @@ theme = "adidoks"
 build_search_index = true
 
 [markdown]
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
+# Syntax highlighting configuration
+[markdown.highlighting]
+theme = "github-dark"
 
 [extra]
 author = "Christian Kemper"


### PR DESCRIPTION
Fixes build error with newer Zola versions.

## Changes
- Replace deprecated `highlight_code` with `[markdown.highlighting]` section
- Set `theme = "github-dark"` (valid Giallo theme)

Resolves the TOML parse error where `highlight_code` is no longer a valid field.