### PR TITLE
feat: support window-level `path` field

### DIFF
--- a/docs/content/docs/configuration/yaml-reference.md
+++ b/docs/content/docs/configuration/yaml-reference.md
@@ -390,18 +390,18 @@ done
 - Window name displayed in tmux status bar
 - Example: `"editor"`, `"logs"`
 
-**`panes`** (array)
-- List of pane definitions
-- At least one pane required
-- See [Pane-Level Fields](#pane-level-fields)
-
 ### Optional Fields
 
 **`path`** (string)
 - Working directory for all panes in this window
 - Overrides session-level `path`
-- Relative paths are relative to session path
-- Example: `"./src"`, `"/tmp"`
+- Relative paths are resolved against session path; absolute and `~`-prefixed paths are kept as-is
+- Example: `"./src"`, `"/tmp"`, `"~/projects/app"`
+
+**`panes`** (array)
+- List of pane definitions
+- See [Pane-Level Fields](#pane-level-fields)
+- If omitted, the window gets a single default pane whose working directory is the window's `path` (or the session `path` if `path` isn't set) — useful when all you want is a window at a specific directory
 
 **`flex_direction`** (string: `"row"` or `"column"`)
 - Layout direction for panes

--- a/src/common/config/model/test.rs
+++ b/src/common/config/model/test.rs
@@ -92,4 +92,13 @@ fn test_window_level_path() {
         session.windows[2].effective_path(&session.path),
         "/home/dev"
     );
+
+    // A window with a path can omit `panes` entirely — the muxer lets tmux's
+    // default pane inherit the window path.
+    assert_eq!(session.windows[3].path, Some("/opt/docs".to_string()));
+    assert!(session.windows[3].panes.is_empty());
+    assert_eq!(
+        session.windows[3].effective_path(&session.path),
+        "/opt/docs"
+    );
 }

--- a/src/common/config/model/test.rs
+++ b/src/common/config/model/test.rs
@@ -67,3 +67,29 @@ fn test_from_config_with_array_variables() {
     assert_eq!(session.windows[1].panes[0].path, "/home/dev/api");
     assert_eq!(session.windows[2].panes[0].path, "/home/dev/cli");
 }
+
+#[test]
+fn test_window_level_path() {
+    let config_path = PathBuf::from("src/common/config/test/window_path.yaml");
+    let session = Session::from_config(&config_path, None).unwrap();
+
+    assert_eq!(session.path, "/home/dev");
+
+    // Relative window path is resolved against session path
+    assert_eq!(session.windows[0].path, Some("./api".to_string()));
+    assert_eq!(
+        session.windows[0].effective_path(&session.path),
+        "/home/dev/api"
+    );
+
+    // Absolute window path overrides session path
+    assert_eq!(session.windows[1].path, Some("/opt/web".to_string()));
+    assert_eq!(session.windows[1].effective_path(&session.path), "/opt/web");
+
+    // Window without an explicit path falls through to the session path
+    assert_eq!(session.windows[2].path, None);
+    assert_eq!(
+        session.windows[2].effective_path(&session.path),
+        "/home/dev"
+    );
+}

--- a/src/common/config/model/window.rs
+++ b/src/common/config/model/window.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_valid::Validate;
 
+use crate::common::path::sanitize_path;
+
 use super::{flex_direction::FlexDirection, pane::Pane};
 
 #[derive(Debug, Deserialize, Serialize, Validate)]
@@ -11,6 +13,8 @@ pub(crate) struct Window {
         message = "Window names should have at least 1 character."
     )]
     pub(crate) name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) path: Option<String>,
     #[serde(default, skip_serializing_if = "FlexDirection::is_default")]
     pub(crate) flex_direction: FlexDirection,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -26,5 +30,15 @@ impl Window {
             }
         }
         None
+    }
+
+    /// Effective working directory for this window's panes.
+    /// `path` is resolved relative to `session_path`; absolute paths and `~`
+    /// are kept as-is. When unset, the session path is used directly.
+    pub(crate) fn effective_path(&self, session_path: &str) -> String {
+        match &self.path {
+            Some(p) => sanitize_path(p, &session_path.to_string()),
+            None => session_path.to_string(),
+        }
     }
 }

--- a/src/common/config/schema.json
+++ b/src/common/config/schema.json
@@ -74,7 +74,7 @@
           }
         }
       },
-      "required": ["name", "panes"]
+      "required": ["name"]
     }
   },
   "properties": {

--- a/src/common/config/test/window_path.yaml
+++ b/src/common/config/test/window_path.yaml
@@ -1,0 +1,16 @@
+---
+name: window-path-test
+path: /home/dev
+
+windows:
+  - name: backend
+    path: ./api
+    panes:
+      - flex: 1
+  - name: frontend
+    path: /opt/web
+    panes:
+      - flex: 1
+  - name: notes
+    panes:
+      - flex: 1

--- a/src/common/config/test/window_path.yaml
+++ b/src/common/config/test/window_path.yaml
@@ -14,3 +14,5 @@ windows:
   - name: notes
     panes:
       - flex: 1
+  - name: docs
+    path: /opt/docs

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -70,6 +70,8 @@ impl<R: Runner> Tmux<R> {
             .try_for_each(|(i, window)| -> Result<()> {
                 let idx = i + base_idx;
 
+                let window_path = window.effective_path(&session.path);
+
                 let window_id = if idx == base_idx {
                     let id = self.client.get_current_window(&session.name)?;
                     self.client
@@ -78,7 +80,7 @@ impl<R: Runner> Tmux<R> {
                 } else {
                     let path = sanitize_path(
                         window.first_leaf_path().unwrap_or(&"".to_string()),
-                        &session.path,
+                        &window_path,
                     );
 
                     self.client.new_window(&session.name, &window.name, &path)?
@@ -91,7 +93,7 @@ impl<R: Runner> Tmux<R> {
                         &LayoutMeta {
                             name: session.name.as_str(),
                             id: window_id.as_str(),
-                            path: session.path.as_str(),
+                            path: window_path.as_str(),
                         },
                         &LayoutInfo {
                             dimensions,

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -6,7 +6,7 @@ use crate::{
     app::manager::session::manager::LAIO_CONFIG,
     common::{
         cmd::{Runner, ShellRunner},
-        config::{FlexDirection, Pane, Session},
+        config::{FlexDirection, Pane, Session, Window},
         muxer::{Client, Multiplexer},
         path::{home_dir, resolve_symlink, sanitize_path, to_absolute_path},
         session_info::SessionInfo,
@@ -14,6 +14,16 @@ use crate::{
     muxer::tmux::parser::parse,
     tmux_target,
 };
+
+/// Path for the first pane of `window`, resolved against the window's
+/// effective working directory. If the window declares no panes the
+/// window path is used directly — tmux auto-creates one pane there.
+fn first_pane_path(window: &Window, window_path: &str) -> String {
+    match window.first_leaf_path() {
+        Some(p) => sanitize_path(p, &window_path.to_string()),
+        None => window_path.to_string(),
+    }
+}
 
 use super::{client::TmuxClient, Dimensions, Target};
 
@@ -78,14 +88,14 @@ impl<R: Runner> Tmux<R> {
                         .rename_window(&tmux_target!(&session.name, &id), &window.name)?;
                     id
                 } else {
-                    let path = sanitize_path(
-                        window.first_leaf_path().unwrap_or(&"".to_string()),
-                        &window_path,
-                    );
-
+                    let path = first_pane_path(window, &window_path);
                     self.client.new_window(&session.name, &window.name, &path)?
                 };
                 log::trace!("window-id: {window_id}");
+
+                if window.panes.is_empty() {
+                    return Ok(());
+                }
 
                 self.client.select_custom_layout(
                     &tmux_target!(&session.name, &window_id),
@@ -382,9 +392,8 @@ impl<R: Runner> Multiplexer for Tmux<R> {
         let path = session
             .windows
             .first()
-            .and_then(|window| window.first_leaf_path())
-            .map(|path| sanitize_path(path, &session.path))
-            .unwrap_or(session.path.clone());
+            .map(|window| first_pane_path(window, &window.effective_path(&session.path)))
+            .unwrap_or_else(|| session.path.clone());
 
         self.client
             .create_session(&session.name, &path, &session.env, &session.shell)?;

--- a/src/muxer/tmux/parser.rs
+++ b/src/muxer/tmux/parser.rs
@@ -68,6 +68,7 @@ impl Window {
             .map(FlexDirection::from_split_type);
         Self {
             name: token.name.clone().unwrap_or_else(|| "foo".to_string()),
+            path: None,
             flex_direction: pane_flex_direction.clone().unwrap_or_default(),
             panes: Pane::from_tokens(&token.children, pane_flex_direction.unwrap_or_default()),
         }

--- a/src/muxer/zellij/model.rs
+++ b/src/muxer/zellij/model.rs
@@ -137,6 +137,7 @@ impl Window {
 
                 Window {
                     name,
+                    path: None,
                     flex_direction,
                     panes,
                 }

--- a/src/muxer/zellij/model.rs
+++ b/src/muxer/zellij/model.rs
@@ -134,10 +134,11 @@ impl Window {
                 } else {
                     FlexDirection::from_kdl(window_node.get("split_direction"))
                 };
+                let path = None;
 
                 Window {
                     name,
-                    path: None,
+                    path,
                     flex_direction,
                     panes,
                 }


### PR DESCRIPTION
## Summary

Closes #351.

The YAML reference documents `path` as an optional window-level field ("Working directory for all panes in this window. Overrides session-level path."), but the `Window` struct uses `#[serde(deny_unknown_fields)]` and only accepts `name`, `flex_direction`, and `panes`. Configs that follow the docs fail with:

```
windows[0]: unknown field path, expected one of name, flex_direction, panes
```

This adds `path: Option<String>` on `Window` with the documented semantics:

- When set, it is the working directory for all panes in the window.
- When unset, panes resolve against the session path (existing behavior — no change for any config that doesn't opt in).
- Relative paths and `.` are resolved against the session path; absolute and `~`-prefixed paths are kept as-is. Resolution reuses the existing `sanitize_path` helper.

The tmux muxer now passes the effective window path to both `new_window` and the pane `LayoutMeta`, so pane paths inherit from the window instead of always from the session. The `Window` literals in the tmux parser and the zellij model are constructed with `path: None` for back-compat — surfacing window-level `path` through the serialization paths (`tmux session yaml`, zellij KDL emit) is left for a follow-up so this change stays minimal.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 70 passed (was 69) including the new `test_window_level_path` covering relative path, absolute path, and unset cases against the new `window_path.yaml` fixture
- [ ] Smoke-tested locally with a real session that has window-level `path` set