### PR TITLE
fix: resolve strict clippy issues and include lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "laio"
-version = "0.16.0"
+version = "0.16.5"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "laio"
-version = "0.16.0"
-edition = "2021"
+version = "0.16.5"
+edition = "2024"
 description = "A simple flexbox-like layout manager for tmux."
 homepage = "https://github.com/ck3mp3r/laio-cli"
 
@@ -18,7 +18,7 @@ strip = "symbols"
 
 [dependencies]
 clap-verbosity-flag = "3.0.4"
-clap_complete = "4.6.1"
+clap_complete = "4.6.3"
 clap_complete_nushell = "4.6.0"
 crossterm = "0.29.0"
 env_logger = "0.11.10"
@@ -35,7 +35,7 @@ tera = "1.20.1"
 urlencoding = "2.1.3"
 
 [dependencies.clap]
-version = "4.6.0"
+version = "4.6.1"
 features = ["derive"]
 
 [dependencies.kdl]

--- a/src/app/manager/config/test.rs
+++ b/src/app/manager/config/test.rs
@@ -6,13 +6,19 @@ use crate::{
     },
 };
 
-use std::{env::set_var, rc::Rc};
+use std::rc::Rc;
+
+fn set_editor_to_vim_for_test() {
+    unsafe {
+        std::env::set_var("EDITOR", "vim");
+    }
+}
 
 #[test]
 fn config_create() {
     let temp_dir = std::env::temp_dir();
     let temp_path = temp_dir.to_str().unwrap().trim_end_matches("/");
-    set_var("EDITOR", "vim");
+    set_editor_to_vim_for_test();
     let mut cmd_unit = MockCmdUnitMock::new();
     let cmd_string = MockCmdStringMock::new();
     let cmd_bool = MockCmdBoolMock::new();
@@ -52,7 +58,7 @@ fn config_create() {
 fn config_edit() {
     let temp_dir = std::env::temp_dir();
     let temp_path = temp_dir.to_str().unwrap();
-    set_var("EDITOR", "vim");
+    set_editor_to_vim_for_test();
     let session_name = "test";
     let mut cmd_unit = MockCmdUnitMock::new();
     let cmd_string = MockCmdStringMock::new();
@@ -161,7 +167,7 @@ fn config_create_uses_default_yaml() {
     let _ = fs::remove_dir_all(&test_dir);
     fs::create_dir_all(&test_dir).expect("Failed to create test dir");
 
-    set_var("EDITOR", "vim");
+    set_editor_to_vim_for_test();
 
     // Create custom _default.yaml
     let custom_default = r#"---
@@ -217,7 +223,7 @@ fn config_create_generates_default_if_missing() {
     let _ = fs::remove_dir_all(&test_dir);
     fs::create_dir_all(&test_dir).expect("Failed to create test dir");
 
-    set_var("EDITOR", "vim");
+    set_editor_to_vim_for_test();
 
     // Ensure _default.yaml doesn't exist
     let default_path = test_dir.join("_default.yaml");
@@ -374,7 +380,7 @@ windows:
     fs::write(test_dir.join("_default.yaml"), template_config)
         .expect("Failed to write default template");
 
-    set_var("EDITOR", "vim");
+    set_editor_to_vim_for_test();
     let mut cmd_unit = MockCmdUnitMock::new();
     let cmd_string = MockCmdStringMock::new();
     let cmd_bool = MockCmdBoolMock::new();
@@ -436,7 +442,7 @@ windows:
     fs::write(test_dir.join("_default.yaml"), template_config)
         .expect("Failed to write default template");
 
-    set_var("EDITOR", "vim");
+    set_editor_to_vim_for_test();
     let mut cmd_unit = MockCmdUnitMock::new();
     let cmd_string = MockCmdStringMock::new();
     let cmd_bool = MockCmdBoolMock::new();

--- a/src/app/manager/session/manager.rs
+++ b/src/app/manager/session/manager.rs
@@ -170,10 +170,10 @@ impl SessionManager {
                 None => match self.select_config(show_picker)? {
                     Some((config, active_session)) => {
                         // If session is already running, switch to it
-                        if let Some(ref session_name) = active_session {
-                            if self.multiplexer.switch(session_name, skip_attach)? {
-                                return Ok(());
-                            }
+                        if let Some(ref session_name) = active_session
+                            && self.multiplexer.switch(session_name, skip_attach)?
+                        {
+                            return Ok(());
                         }
 
                         let resolved = resolve_symlink(&config)

--- a/src/muxer/tmux/client.rs
+++ b/src/muxer/tmux/client.rs
@@ -541,11 +541,12 @@ impl<R: Runner> TmuxClient<R> {
                     .into_iter()
                     .filter(|&pid| pid != current_pid.parse::<i32>().unwrap_or(0))
                 {
-                    if let Some(command) = Self::get_process_command(child_pid) {
-                        if !command.is_empty() && !command.starts_with('-') {
-                            pane_map.insert(pane_id.replace('%', ""), command);
-                            break;
-                        }
+                    if let Some(command) = Self::get_process_command(child_pid)
+                        && !command.is_empty()
+                        && !command.starts_with('-')
+                    {
+                        pane_map.insert(pane_id.replace('%', ""), command);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## What
- fix `clippy::collapsible_if` warnings in session manager and tmux client
- update config manager tests for current Rust safety requirements around `std::env::set_var`
- include corresponding `Cargo.lock` update

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`