### PR TITLE
feat: add --tmux-socket flag and TmuxClient socket routing

### DIFF
--- a/src/app/cli/command_line.rs
+++ b/src/app/cli/command_line.rs
@@ -25,10 +25,6 @@ enum Commands {
         #[clap(short, long)]
         muxer: Option<Muxer>,
 
-        /// tmux socket path; takes priority over LAIO_TMUX_SOCKET env var.
-        #[clap(long)]
-        tmux_socket: Option<String>,
-
         /// Show config picker
         #[clap(short = 'p', long)]
         show_picker: bool,
@@ -103,6 +99,10 @@ pub struct Cli {
     #[arg[long, default_value = "~/.config/laio", global=true]]
     pub config_dir: String,
 
+    /// tmux socket path; takes priority over LAIO_TMUX_SOCKET env var.
+    #[arg(long, global = true)]
+    pub tmux_socket: Option<String>,
+
     #[clap(flatten)]
     pub verbose: clap_verbosity_flag::Verbosity,
 }
@@ -123,26 +123,21 @@ impl Cli {
                 name,
                 file,
                 muxer,
-                tmux_socket,
                 show_picker,
                 skip_cmds,
                 skip_attach,
                 variables,
-            } => {
-                let resolved_socket = tmux_socket
-                    .clone()
-                    .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok());
-                self.session_with_socket(muxer, resolved_socket)?
-                    .start(
-                        name,
-                        file,
-                        variables,
-                        *show_picker,
-                        *skip_cmds,
-                        *skip_attach,
-                    )
-                    .wrap_err("Could not start session!".to_string())
-            }
+            } => self
+                .session(muxer)?
+                .start(
+                    name,
+                    file,
+                    variables,
+                    *show_picker,
+                    *skip_cmds,
+                    *skip_attach,
+                )
+                .wrap_err("Could not start session!".to_string()),
             Commands::Stop {
                 name,
                 muxer,
@@ -192,8 +187,8 @@ impl Cli {
                 }
                 Ok(())
             }
-            Commands::Config(cli) => cli.run(&self.config_dir),
-            Commands::Session(cli) => cli.run(&self.config_dir),
+            Commands::Config(cli) => cli.run(&self.config_dir, self.resolved_socket()),
+            Commands::Session(cli) => cli.run(&self.config_dir, self.resolved_socket()),
             Commands::Completion(cli) => cli.run(),
         };
 
@@ -206,7 +201,7 @@ impl Cli {
     }
 
     fn session(&self, muxer: &Option<Muxer>) -> Result<SessionManager> {
-        self.session_with_socket(muxer, None)
+        self.session_with_socket(muxer, self.resolved_socket())
     }
 
     fn session_with_socket(
@@ -216,6 +211,12 @@ impl Cli {
     ) -> Result<SessionManager> {
         let muxer = create_muxer(muxer, socket).wrap_err("Could not create desired multiplexer")?;
         Ok(SessionManager::new(&self.config_dir, muxer))
+    }
+
+    fn resolved_socket(&self) -> Option<String> {
+        self.tmux_socket
+            .clone()
+            .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok())
     }
 
     fn config(&self) -> ConfigManager<ShellRunner> {
@@ -265,20 +266,14 @@ mod tests {
     #[test]
     fn start_socket_flag_is_parsed() {
         let cli = parse(&["start", "--tmux-socket", "/tmp/test.sock", "--skip-attach"]);
-        let Commands::Start { tmux_socket, .. } = &cli.commands else {
-            panic!("expected Start subcommand");
-        };
-        assert_eq!(tmux_socket.as_deref(), Some("/tmp/test.sock"));
+        assert_eq!(cli.tmux_socket.as_deref(), Some("/tmp/test.sock"));
     }
 
     // absent `--tmux-socket` flag leaves the field None.
     #[test]
     fn start_socket_flag_absent_is_none() {
         let cli = parse(&["start", "--skip-attach"]);
-        let Commands::Start { tmux_socket, .. } = &cli.commands else {
-            panic!("expected Start subcommand");
-        };
-        assert!(tmux_socket.is_none());
+        assert!(cli.tmux_socket.is_none());
     }
 
     // LAIO_TMUX_SOCKET env var is honoured when --tmux-socket is absent.
@@ -288,15 +283,8 @@ mod tests {
         // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
         unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-test.sock") };
         let cli = parse(&["start", "--skip-attach"]);
-        let Commands::Start { tmux_socket, .. } = &cli.commands else {
-            panic!("expected Start subcommand");
-        };
-        // The field itself is None (flag not provided)…
-        assert!(tmux_socket.is_none());
-        // …but the resolution logic produces the env value.
-        let resolved = tmux_socket
-            .clone()
-            .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok());
+        assert!(cli.tmux_socket.is_none());
+        let resolved = cli.resolved_socket();
         // SAFETY: restoring env state.
         unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
         assert_eq!(resolved.as_deref(), Some("/tmp/env-test.sock"));
@@ -309,14 +297,15 @@ mod tests {
         // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
         unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-value.sock") };
         let cli = parse(&["start", "--tmux-socket", "/tmp/flag-value.sock", "--skip-attach"]);
-        let Commands::Start { tmux_socket, .. } = &cli.commands else {
-            panic!("expected Start subcommand");
-        };
-        let resolved = tmux_socket
-            .clone()
-            .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok());
+        let resolved = cli.resolved_socket();
         // SAFETY: restoring env state.
         unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
         assert_eq!(resolved.as_deref(), Some("/tmp/flag-value.sock"));
+    }
+
+    #[test]
+    fn socket_flag_is_global() {
+        let cli = parse(&["session", "list", "--tmux-socket", "/tmp/test.sock"]);
+        assert_eq!(cli.tmux_socket.as_deref(), Some("/tmp/test.sock"));
     }
 }

--- a/src/app/cli/command_line.rs
+++ b/src/app/cli/command_line.rs
@@ -7,7 +7,7 @@ use tabled::{builder::Builder, settings::Style};
 use crate::{
     app::{ConfigManager, SessionManager},
     common::{cmd::ShellRunner, path::to_absolute_path, session_info::SessionInfo},
-    muxer::{create_muxer, Muxer},
+    muxer::{Muxer, create_muxer},
 };
 
 #[derive(Subcommand, Debug)]
@@ -24,6 +24,10 @@ enum Commands {
         /// Specify the multiplexer to use. Note: Zellij support is experimental!
         #[clap(short, long)]
         muxer: Option<Muxer>,
+
+        /// tmux socket path; takes priority over LAIO_TMUX_SOCKET env var.
+        #[clap(long)]
+        tmux_socket: Option<String>,
 
         /// Show config picker
         #[clap(short = 'p', long)]
@@ -119,21 +123,26 @@ impl Cli {
                 name,
                 file,
                 muxer,
+                tmux_socket,
                 show_picker,
                 skip_cmds,
                 skip_attach,
                 variables,
-            } => self
-                .session(muxer)?
-                .start(
-                    name,
-                    file,
-                    variables,
-                    *show_picker,
-                    *skip_cmds,
-                    *skip_attach,
-                )
-                .wrap_err("Could not start session!".to_string()),
+            } => {
+                let resolved_socket = tmux_socket
+                    .clone()
+                    .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok());
+                self.session_with_socket(muxer, resolved_socket)?
+                    .start(
+                        name,
+                        file,
+                        variables,
+                        *show_picker,
+                        *skip_cmds,
+                        *skip_attach,
+                    )
+                    .wrap_err("Could not start session!".to_string())
+            }
             Commands::Stop {
                 name,
                 muxer,
@@ -197,7 +206,15 @@ impl Cli {
     }
 
     fn session(&self, muxer: &Option<Muxer>) -> Result<SessionManager> {
-        let muxer = create_muxer(muxer).wrap_err("Could not create desired multiplexer")?;
+        self.session_with_socket(muxer, None)
+    }
+
+    fn session_with_socket(
+        &self,
+        muxer: &Option<Muxer>,
+        socket: Option<String>,
+    ) -> Result<SessionManager> {
+        let muxer = create_muxer(muxer, socket).wrap_err("Could not create desired multiplexer")?;
         Ok(SessionManager::new(&self.config_dir, muxer))
     }
 
@@ -228,5 +245,78 @@ impl Cli {
                 log::warn!("No tmux session to shut down!");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::sync::Mutex;
+
+    // Serialize env-var tests to avoid races when Rust's test runner uses multiple threads.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::parse_from(std::iter::once("laio").chain(args.iter().copied()))
+    }
+
+    // `--tmux-socket` flag is parsed and stored on the Start subcommand.
+    #[test]
+    fn start_socket_flag_is_parsed() {
+        let cli = parse(&["start", "--tmux-socket", "/tmp/test.sock", "--skip-attach"]);
+        let Commands::Start { tmux_socket, .. } = &cli.commands else {
+            panic!("expected Start subcommand");
+        };
+        assert_eq!(tmux_socket.as_deref(), Some("/tmp/test.sock"));
+    }
+
+    // absent `--tmux-socket` flag leaves the field None.
+    #[test]
+    fn start_socket_flag_absent_is_none() {
+        let cli = parse(&["start", "--skip-attach"]);
+        let Commands::Start { tmux_socket, .. } = &cli.commands else {
+            panic!("expected Start subcommand");
+        };
+        assert!(tmux_socket.is_none());
+    }
+
+    // LAIO_TMUX_SOCKET env var is honoured when --tmux-socket is absent.
+    #[test]
+    fn start_socket_resolved_from_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
+        unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-test.sock") };
+        let cli = parse(&["start", "--skip-attach"]);
+        let Commands::Start { tmux_socket, .. } = &cli.commands else {
+            panic!("expected Start subcommand");
+        };
+        // The field itself is None (flag not provided)…
+        assert!(tmux_socket.is_none());
+        // …but the resolution logic produces the env value.
+        let resolved = tmux_socket
+            .clone()
+            .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok());
+        // SAFETY: restoring env state.
+        unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
+        assert_eq!(resolved.as_deref(), Some("/tmp/env-test.sock"));
+    }
+
+    // explicit --tmux-socket takes priority over LAIO_TMUX_SOCKET env var.
+    #[test]
+    fn start_socket_flag_overrides_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
+        unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-value.sock") };
+        let cli = parse(&["start", "--tmux-socket", "/tmp/flag-value.sock", "--skip-attach"]);
+        let Commands::Start { tmux_socket, .. } = &cli.commands else {
+            panic!("expected Start subcommand");
+        };
+        let resolved = tmux_socket
+            .clone()
+            .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok());
+        // SAFETY: restoring env state.
+        unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
+        assert_eq!(resolved.as_deref(), Some("/tmp/flag-value.sock"));
     }
 }

--- a/src/app/cli/command_line.rs
+++ b/src/app/cli/command_line.rs
@@ -213,7 +213,7 @@ impl Cli {
         Ok(SessionManager::new(&self.config_dir, muxer))
     }
 
-    fn resolved_socket(&self) -> Option<String> {
+    pub(crate) fn resolved_socket(&self) -> Option<String> {
         self.tmux_socket
             .clone()
             .or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok())
@@ -246,66 +246,5 @@ impl Cli {
                 log::warn!("No tmux session to shut down!");
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-    use std::sync::Mutex;
-
-    // Serialize env-var tests to avoid races when Rust's test runner uses multiple threads.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn parse(args: &[&str]) -> Cli {
-        Cli::parse_from(std::iter::once("laio").chain(args.iter().copied()))
-    }
-
-    // `--tmux-socket` flag is parsed and stored on the Start subcommand.
-    #[test]
-    fn start_socket_flag_is_parsed() {
-        let cli = parse(&["start", "--tmux-socket", "/tmp/test.sock", "--skip-attach"]);
-        assert_eq!(cli.tmux_socket.as_deref(), Some("/tmp/test.sock"));
-    }
-
-    // absent `--tmux-socket` flag leaves the field None.
-    #[test]
-    fn start_socket_flag_absent_is_none() {
-        let cli = parse(&["start", "--skip-attach"]);
-        assert!(cli.tmux_socket.is_none());
-    }
-
-    // LAIO_TMUX_SOCKET env var is honoured when --tmux-socket is absent.
-    #[test]
-    fn start_socket_resolved_from_env_var() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
-        unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-test.sock") };
-        let cli = parse(&["start", "--skip-attach"]);
-        assert!(cli.tmux_socket.is_none());
-        let resolved = cli.resolved_socket();
-        // SAFETY: restoring env state.
-        unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
-        assert_eq!(resolved.as_deref(), Some("/tmp/env-test.sock"));
-    }
-
-    // explicit --tmux-socket takes priority over LAIO_TMUX_SOCKET env var.
-    #[test]
-    fn start_socket_flag_overrides_env_var() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
-        unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-value.sock") };
-        let cli = parse(&["start", "--tmux-socket", "/tmp/flag-value.sock", "--skip-attach"]);
-        let resolved = cli.resolved_socket();
-        // SAFETY: restoring env state.
-        unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
-        assert_eq!(resolved.as_deref(), Some("/tmp/flag-value.sock"));
-    }
-
-    #[test]
-    fn socket_flag_is_global() {
-        let cli = parse(&["session", "list", "--tmux-socket", "/tmp/test.sock"]);
-        assert_eq!(cli.tmux_socket.as_deref(), Some("/tmp/test.sock"));
     }
 }

--- a/src/app/cli/command_line_test.rs
+++ b/src/app/cli/command_line_test.rs
@@ -1,0 +1,57 @@
+use super::command_line::Cli;
+use clap::Parser;
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn parse(args: &[&str]) -> Cli {
+    Cli::parse_from(std::iter::once("laio").chain(args.iter().copied()))
+}
+
+#[test]
+fn start_socket_flag_is_parsed() {
+    let cli = parse(&["start", "--tmux-socket", "/tmp/test.sock", "--skip-attach"]);
+    assert_eq!(cli.tmux_socket.as_deref(), Some("/tmp/test.sock"));
+}
+
+#[test]
+fn start_socket_flag_absent_is_none() {
+    let cli = parse(&["start", "--skip-attach"]);
+    assert!(cli.tmux_socket.is_none());
+}
+
+#[test]
+fn start_socket_resolved_from_env_var() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
+    unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-test.sock") };
+    let cli = parse(&["start", "--skip-attach"]);
+    assert!(cli.tmux_socket.is_none());
+    let resolved = cli.resolved_socket();
+    // SAFETY: restoring env state.
+    unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
+    assert_eq!(resolved.as_deref(), Some("/tmp/env-test.sock"));
+}
+
+#[test]
+fn start_socket_flag_overrides_env_var() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    // SAFETY: test is serialized via ENV_LOCK; no concurrent env access.
+    unsafe { std::env::set_var("LAIO_TMUX_SOCKET", "/tmp/env-value.sock") };
+    let cli = parse(&[
+        "start",
+        "--tmux-socket",
+        "/tmp/flag-value.sock",
+        "--skip-attach",
+    ]);
+    let resolved = cli.resolved_socket();
+    // SAFETY: restoring env state.
+    unsafe { std::env::remove_var("LAIO_TMUX_SOCKET") };
+    assert_eq!(resolved.as_deref(), Some("/tmp/flag-value.sock"));
+}
+
+#[test]
+fn socket_flag_is_global() {
+    let cli = parse(&["session", "list", "--tmux-socket", "/tmp/test.sock"]);
+    assert_eq!(cli.tmux_socket.as_deref(), Some("/tmp/test.sock"));
+}

--- a/src/app/cli/config/cli.rs
+++ b/src/app/cli/config/cli.rs
@@ -108,7 +108,7 @@ impl Cli {
             Commands::Delete { name, force } => cfg.delete(name, *force),
             Commands::List { muxer, json } => {
                 let muxer =
-                    create_muxer(muxer).wrap_err("Could not create desired multiplexer.")?;
+                    create_muxer(muxer, None).wrap_err("Could not create desired multiplexer.")?;
                 let session_manager = SessionManager::new(config_path, muxer);
 
                 let sessions = session_manager.list()?;

--- a/src/app/cli/config/cli.rs
+++ b/src/app/cli/config/cli.rs
@@ -89,7 +89,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn run(&self, config_path: &str) -> Result<()> {
+    pub fn run(&self, config_path: &str, socket: Option<String>) -> Result<()> {
         let cfg = ConfigManager::new(config_path, Rc::new(ShellRunner::new()));
 
         match &self.commands {
@@ -108,7 +108,7 @@ impl Cli {
             Commands::Delete { name, force } => cfg.delete(name, *force),
             Commands::List { muxer, json } => {
                 let muxer =
-                    create_muxer(muxer, None).wrap_err("Could not create desired multiplexer.")?;
+                    create_muxer(muxer, socket).wrap_err("Could not create desired multiplexer.")?;
                 let session_manager = SessionManager::new(config_path, muxer);
 
                 let sessions = session_manager.list()?;

--- a/src/app/cli/mod.rs
+++ b/src/app/cli/mod.rs
@@ -3,3 +3,6 @@ mod completion;
 mod config;
 mod session;
 pub use command_line::Cli;
+
+#[cfg(test)]
+mod command_line_test;

--- a/src/app/cli/session/cli.rs
+++ b/src/app/cli/session/cli.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::SessionManager,
-    muxer::{create_muxer, Muxer},
+    muxer::{Muxer, create_muxer},
 };
 
 use clap::{Args, Subcommand};
@@ -42,7 +42,7 @@ impl Cli {
         match &self.commands {
             Commands::List { muxer, json } => {
                 let muxer =
-                    create_muxer(muxer).wrap_err("Could not create desired multiplexer.")?;
+                    create_muxer(muxer, None).wrap_err("Could not create desired multiplexer.")?;
                 let session = SessionManager::new(config_path, muxer);
 
                 let list = session.list()?;
@@ -64,7 +64,7 @@ impl Cli {
             }
             Commands::Yaml { muxer } => {
                 let muxer =
-                    create_muxer(muxer).wrap_err("Could not create desired multiplexer.")?;
+                    create_muxer(muxer, None).wrap_err("Could not create desired multiplexer.")?;
                 let session = SessionManager::new(config_path, muxer);
 
                 let yaml = session.to_yaml()?;

--- a/src/app/cli/session/cli.rs
+++ b/src/app/cli/session/cli.rs
@@ -38,11 +38,12 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn run(&self, config_path: &str) -> Result<()> {
+    pub fn run(&self, config_path: &str, socket: Option<String>) -> Result<()> {
         match &self.commands {
             Commands::List { muxer, json } => {
                 let muxer =
-                    create_muxer(muxer, None).wrap_err("Could not create desired multiplexer.")?;
+                    create_muxer(muxer, socket.clone())
+                        .wrap_err("Could not create desired multiplexer.")?;
                 let session = SessionManager::new(config_path, muxer);
 
                 let list = session.list()?;
@@ -64,7 +65,7 @@ impl Cli {
             }
             Commands::Yaml { muxer } => {
                 let muxer =
-                    create_muxer(muxer, None).wrap_err("Could not create desired multiplexer.")?;
+                    create_muxer(muxer, socket).wrap_err("Could not create desired multiplexer.")?;
                 let session = SessionManager::new(config_path, muxer);
 
                 let yaml = session.to_yaml()?;

--- a/src/muxer/mod.rs
+++ b/src/muxer/mod.rs
@@ -1,6 +1,6 @@
 use crate::common::muxer::Multiplexer;
 use clap::ValueEnum;
-use miette::{bail, Result};
+use miette::{Result, bail};
 use std::env;
 pub(crate) mod tmux;
 pub(crate) mod zellij;
@@ -13,7 +13,10 @@ pub(crate) enum Muxer {
     Zellij,
 }
 
-pub(crate) fn create_muxer(muxer: &Option<Muxer>) -> Result<Box<dyn Multiplexer>> {
+pub(crate) fn create_muxer(
+    muxer: &Option<Muxer>,
+    socket: Option<String>,
+) -> Result<Box<dyn Multiplexer>> {
     let muxer = match muxer {
         Some(m) => m.clone(),
         None => match env::var("LAIO_MUXER") {
@@ -30,7 +33,12 @@ pub(crate) fn create_muxer(muxer: &Option<Muxer>) -> Result<Box<dyn Multiplexer>
     };
 
     match muxer {
-        Muxer::Tmux => Ok(Box::new(Tmux::new())),
-        Muxer::Zellij => Ok(Box::new(Zellij::new())),
+        Muxer::Tmux => Ok(Box::new(Tmux::new_with_socket(socket))),
+        Muxer::Zellij => {
+            if socket.is_some() {
+                log::warn!("--tmux-socket is not supported by Zellij and will be ignored");
+            }
+            Ok(Box::new(Zellij::new()))
+        }
     }
 }

--- a/src/muxer/tmux/client.rs
+++ b/src/muxer/tmux/client.rs
@@ -1,6 +1,6 @@
 use crossterm::terminal::size;
 use log::trace;
-use miette::{bail, miette, IntoDiagnostic, Result};
+use miette::{IntoDiagnostic, Result, bail, miette};
 use serde::Deserialize;
 use serde_yaml::from_str;
 use std::{
@@ -34,6 +34,7 @@ pub(crate) struct Dimensions {
 pub(crate) struct TmuxClient<R: Runner> {
     pub cmd_runner: Arc<R>,
     pub cmds: RefCell<HashMap<Target, VecDeque<Type>>>,
+    socket: Option<String>,
 }
 
 impl<R: Runner> Client<R> for TmuxClient<R> {
@@ -43,11 +44,30 @@ impl<R: Runner> Client<R> for TmuxClient<R> {
 }
 
 impl<R: Runner> TmuxClient<R> {
+    #[cfg(test)]
     pub(crate) fn new(cmd_runner: Arc<R>) -> Self {
         Self {
             cmd_runner,
             cmds: RefCell::new(HashMap::new()),
+            socket: None,
         }
+    }
+
+    pub(crate) fn new_with_socket(cmd_runner: Arc<R>, socket: Option<String>) -> Self {
+        Self {
+            cmd_runner,
+            cmds: RefCell::new(HashMap::new()),
+            socket,
+        }
+    }
+
+    /// Returns a `Command` for `tmux`, prepending `-S <socket>` when a socket is configured.
+    fn tmux_cmd(&self) -> Command {
+        let mut cmd = Command::new("tmux");
+        if let Some(ref s) = self.socket {
+            cmd.arg("-S").arg(s);
+        }
+        cmd
     }
 
     pub(crate) fn create_session(
@@ -67,40 +87,51 @@ impl<R: Runner> TmuxClient<R> {
         args.extend(env_args.iter().map(|s| s.as_str()));
 
         let _: () = self.cmd_runner.run(&Type::Basic({
-            let mut command = Command::new("tmux");
+            let mut command = self.tmux_cmd();
             command.args(args);
             command
         }))?;
 
         if let Some(shell_path) = shell {
-            let _: () = self.cmd_runner.run(&cmd_basic!(
-                "tmux",
-                args = [
+            let _: () = self.cmd_runner.run(&Type::Basic({
+                let mut command = self.tmux_cmd();
+                command.args([
                     "set-option",
                     "-t",
                     session_name,
                     "default-shell",
-                    &shell_path
-                ]
-            ))?;
+                    shell_path,
+                ]);
+                command
+            }))?;
         }
         Ok(())
     }
 
     pub(crate) fn session_exists(&self, name: &str) -> bool {
         self.cmd_runner
-            .run(&cmd_basic!("tmux", args = ["has-session", "-t", name]))
+            .run(&Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args(["has-session", "-t", name]);
+                cmd
+            }))
             .unwrap_or(false)
     }
 
     pub(crate) fn switch_client(&self, name: &str) -> Result<()> {
-        self.cmd_runner
-            .run(&cmd_basic!("tmux", args = ["switch-client", "-t", name]))
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["switch-client", "-t", name]);
+            cmd
+        }))
     }
 
     pub(crate) fn attach_session(&self, name: &str) -> Result<()> {
-        self.cmd_runner
-            .run(&cmd_basic!("tmux", args = ["attach-session", "-t", name]))
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["attach-session", "-t", name]);
+            cmd
+        }))
     }
 
     pub(crate) fn is_inside_session(&self) -> bool {
@@ -121,8 +152,11 @@ impl<R: Runner> TmuxClient<R> {
 
     pub(crate) fn stop_session(&self, name: &str) -> Result<()> {
         if self.session_exists(name) {
-            self.cmd_runner
-                .run(&cmd_basic!("tmux", args = ["kill-session", "-t", name]))
+            self.cmd_runner.run(&Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args(["kill-session", "-t", name]);
+                cmd
+            }))
         } else {
             Ok(())
         }
@@ -134,9 +168,9 @@ impl<R: Runner> TmuxClient<R> {
         window_name: &str,
         path: &str,
     ) -> Result<String> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = [
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args([
                 "new-window",
                 "-Pd",
                 "-t",
@@ -146,57 +180,67 @@ impl<R: Runner> TmuxClient<R> {
                 "-c",
                 path,
                 "-F",
-                "#{window_id}"
-            ]
-        ))
+                "#{window_id}",
+            ]);
+            cmd
+        }))
     }
 
     pub(crate) fn get_current_window(&self, session_name: &str) -> Result<String> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["display-message", "-t", session_name, "-p", "#I"]
-        ))
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["display-message", "-t", session_name, "-p", "#I"]);
+            cmd
+        }))
     }
 
     pub(crate) fn split_window(&self, target: &Target, path: &str) -> Result<String> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = [
+        let target_str = target.to_string();
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args([
                 "split-window",
                 "-t",
-                target.to_string(),
+                &target_str,
                 "-c",
                 path,
                 "-P",
                 "-F",
-                "#{pane_id}"
-            ]
-        ))
+                "#{pane_id}",
+            ]);
+            cmd
+        }))
     }
 
     pub(crate) fn get_current_pane(&self, target: &Target) -> Result<String> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["display-message", "-t", target.to_string(), "-p", "#P"]
-        ))
+        let target_str = target.to_string();
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["display-message", "-t", &target_str, "-p", "#P"]);
+            cmd
+        }))
     }
 
     pub(crate) fn setenv(&self, target: &Target, name: &str, value: &str) {
+        let target_str = target.to_string();
         self.cmds
             .borrow_mut()
             .entry(target.clone())
             .or_default()
-            .push_back(cmd_basic!(
-                "tmux",
-                args = ["set-environment", "-t", target.to_string(), name, value]
-            ))
+            .push_back(Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args(["set-environment", "-t", &target_str, name, value]);
+                cmd
+            }))
     }
 
     pub(crate) fn getenv(&self, target: &Target, name: &str) -> Result<String> {
-        let output: String = self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["show-environment", "-t", target.to_string(), name]
-        ))?;
+        let target_str = target.to_string();
+        let output: String = self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["show-environment", "-t", &target_str, name]);
+            cmd
+        }))?;
         output
             .trim()
             .split_once('=')
@@ -215,7 +259,7 @@ impl<R: Runner> TmuxClient<R> {
         }
 
         // Build command: tmux send-keys -t target cmd1 C-m cmd2 C-m ...
-        let mut command = Command::new("tmux");
+        let mut command = self.tmux_cmd();
         command.arg("send-keys").arg("-t").arg(target.to_string());
 
         // Interleave commands with C-m using flat_map
@@ -231,25 +275,29 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn zoom_pane(&self, target: &Target) {
+        let target_str = target.to_string();
         self.cmds
             .borrow_mut()
             .entry(target.clone())
             .or_default()
-            .push_back(cmd_basic!(
-                "tmux",
-                args = ["resize-pane", "-Z", "-t", target.to_string()]
-            ))
+            .push_back(Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args(["resize-pane", "-Z", "-t", &target_str]);
+                cmd
+            }))
     }
 
     pub(crate) fn focus_pane(&self, target: &Target) {
+        let target_str = target.to_string();
         self.cmds
             .borrow_mut()
             .entry(target.clone())
             .or_default()
-            .push_back(cmd_basic!(
-                "tmux",
-                args = ["select-pane", "-Z", "-t", target.to_string()]
-            ))
+            .push_back(Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args(["select-pane", "-Z", "-t", &target_str]);
+                cmd
+            }))
     }
 
     pub(crate) fn flush_commands(&self) {
@@ -283,10 +331,12 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn select_layout(&self, target: &Target, layout: &str) -> Result<()> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["select-layout", "-t", target.to_string(), layout]
-        ))
+        let target_str = target.to_string();
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["select-layout", "-t", &target_str, layout]);
+            cmd
+        }))
     }
 
     pub(crate) fn select_custom_layout(&self, target: &Target, layout: &str) -> Result<()> {
@@ -307,14 +357,15 @@ impl<R: Runner> TmuxClient<R> {
     pub(crate) fn get_dimensions(&self) -> Result<Dimensions> {
         let res: String = if self.is_inside_session() {
             log::debug!("Inside session, using tmux dimensions.");
-            self.cmd_runner.run(&cmd_basic!(
-                "tmux",
-                args = [
+            self.cmd_runner.run(&Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args([
                     "display-message",
                     "-p",
-                    "width: #{window_width}\nheight: #{window_height}"
-                ]
-            ))?
+                    "width: #{window_width}\nheight: #{window_height}",
+                ]);
+                cmd
+            }))?
         } else {
             log::debug!("Outside session, using terminal dimensions.");
             let (width, height) = size().into_diagnostic()?;
@@ -327,10 +378,11 @@ impl<R: Runner> TmuxClient<R> {
 
     pub(crate) fn list_sessions(&self) -> Result<Vec<(String, bool)>> {
         self.cmd_runner
-            .run(&cmd_basic!(
-                "tmux",
-                args = ["ls", "-F", "#{session_name}|#{session_attached}"]
-            ))
+            .run(&Type::Basic({
+                let mut cmd = self.tmux_cmd();
+                cmd.args(["ls", "-F", "#{session_name}|#{session_attached}"]);
+                cmd
+            }))
             .map(|res: String| {
                 res.lines()
                     .filter_map(|line| {
@@ -349,10 +401,11 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn get_base_idx(&self) -> Result<usize> {
-        let res: String = self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["show-options", "-g", "base-index"]
-        ))?;
+        let res: String = self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["show-options", "-g", "base-index"]);
+            cmd
+        }))?;
         res.split_whitespace()
             .last()
             .unwrap_or("0")
@@ -361,10 +414,12 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn set_pane_style(&self, target: &Target, style: &str) -> Result<()> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["select-pane", "-t", target.to_string(), "-P", style]
-        ))
+        let target_str = target.to_string();
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["select-pane", "-t", &target_str, "-P", style]);
+            cmd
+        }))
     }
 
     pub(crate) fn bind_key(&self, key: &str, cmd: &str) -> Result<()> {
@@ -376,33 +431,40 @@ impl<R: Runner> TmuxClient<R> {
             _ => {
                 return Err(miette!(
                     "Invalid key format: expected 'table key' or just 'key'"
-                ))
+                ));
             }
         };
 
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["bind-key", "-T", table, key, cmd]
-        ))
+        self.cmd_runner.run(&Type::Basic({
+            let mut c = self.tmux_cmd();
+            c.args(["bind-key", "-T", table, key, cmd]);
+            c
+        }))
     }
 
     pub(crate) fn session_name(&self) -> Result<String> {
-        self.cmd_runner
-            .run(&cmd_basic!("tmux", args = ["display-message", "-p", "#S"]))
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["display-message", "-p", "#S"]);
+            cmd
+        }))
     }
 
     pub(crate) fn session_layout(&self) -> Result<String> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["list-windows", "-F", "\"#{window_name} #{window_layout}\""]
-        ))
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["list-windows", "-F", "\"#{window_name} #{window_layout}\""]);
+            cmd
+        }))
     }
 
     pub(crate) fn rename_window(&self, target: &Target, name: &str) -> Result<()> {
-        self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["rename-window", "-t", target.to_string(), name]
-        ))
+        let target_str = target.to_string();
+        self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["rename-window", "-t", &target_str, name]);
+            cmd
+        }))
     }
 
     pub(crate) fn session_start_path(&self) -> Result<String> {
@@ -471,10 +533,11 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn pane_paths(&self) -> Result<HashMap<String, String>> {
-        let output: String = self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["list-panes", "-s", "-F", "#{pane_id} #{pane_current_path}"]
-        ))?;
+        let output: String = self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["list-panes", "-s", "-F", "#{pane_id} #{pane_current_path}"]);
+            cmd
+        }))?;
 
         let pane_map = output
             .lines()
@@ -496,10 +559,11 @@ impl<R: Runner> TmuxClient<R> {
     pub(crate) fn pane_command(&self) -> Result<HashMap<String, String>> {
         let current_pid = process::id().to_string();
 
-        let output: String = self.cmd_runner.run(&cmd_basic!(
-            "tmux",
-            args = ["list-panes", "-s", "-F", "#{pane_id} #{pane_pid}"]
-        ))?;
+        let output: String = self.cmd_runner.run(&Type::Basic({
+            let mut cmd = self.tmux_cmd();
+            cmd.args(["list-panes", "-s", "-F", "#{pane_id} #{pane_pid}"]);
+            cmd
+        }))?;
 
         let mut pane_map: HashMap<String, String> = HashMap::new();
 

--- a/src/muxer/tmux/client.rs
+++ b/src/muxer/tmux/client.rs
@@ -70,6 +70,10 @@ impl<R: Runner> TmuxClient<R> {
         cmd
     }
 
+    pub(crate) fn socket(&self) -> Option<&str> {
+        self.socket.as_deref()
+    }
+
     pub(crate) fn create_session(
         &self,
         session_name: &str,

--- a/src/muxer/tmux/client.rs
+++ b/src/muxer/tmux/client.rs
@@ -24,6 +24,19 @@ use crate::{
 
 use super::Target;
 
+macro_rules! tmux_cmd {
+    ($socket:expr $(, args = [$($args:expr),*])?) => {
+        Type::Basic({
+            let mut command = std::process::Command::new("tmux");
+            if let Some(s) = $socket {
+                command.arg("-S").arg(s);
+            }
+            $( $(command.arg($args);)* )?
+            command
+        })
+    };
+}
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct Dimensions {
     pub width: usize,
@@ -61,7 +74,6 @@ impl<R: Runner> TmuxClient<R> {
         }
     }
 
-    /// Returns a `Command` for `tmux`, prepending `-S <socket>` when a socket is configured.
     fn tmux_cmd(&self) -> Command {
         let mut cmd = Command::new("tmux");
         if let Some(ref s) = self.socket {
@@ -97,45 +109,41 @@ impl<R: Runner> TmuxClient<R> {
         }))?;
 
         if let Some(shell_path) = shell {
-            let _: () = self.cmd_runner.run(&Type::Basic({
-                let mut command = self.tmux_cmd();
-                command.args([
+            let _: () = self.cmd_runner.run(&tmux_cmd!(
+                self.socket.as_deref(),
+                args = [
                     "set-option",
                     "-t",
                     session_name,
                     "default-shell",
-                    shell_path,
-                ]);
-                command
-            }))?;
+                    shell_path
+                ]
+            ))?;
         }
         Ok(())
     }
 
     pub(crate) fn session_exists(&self, name: &str) -> bool {
         self.cmd_runner
-            .run(&Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args(["has-session", "-t", name]);
-                cmd
-            }))
+            .run(&tmux_cmd!(
+                self.socket.as_deref(),
+                args = ["has-session", "-t", name]
+            ))
             .unwrap_or(false)
     }
 
     pub(crate) fn switch_client(&self, name: &str) -> Result<()> {
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["switch-client", "-t", name]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["switch-client", "-t", name]
+        ))
     }
 
     pub(crate) fn attach_session(&self, name: &str) -> Result<()> {
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["attach-session", "-t", name]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["attach-session", "-t", name]
+        ))
     }
 
     pub(crate) fn is_inside_session(&self) -> bool {
@@ -156,11 +164,10 @@ impl<R: Runner> TmuxClient<R> {
 
     pub(crate) fn stop_session(&self, name: &str) -> Result<()> {
         if self.session_exists(name) {
-            self.cmd_runner.run(&Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args(["kill-session", "-t", name]);
-                cmd
-            }))
+            self.cmd_runner.run(&tmux_cmd!(
+                self.socket.as_deref(),
+                args = ["kill-session", "-t", name]
+            ))
         } else {
             Ok(())
         }
@@ -172,9 +179,9 @@ impl<R: Runner> TmuxClient<R> {
         window_name: &str,
         path: &str,
     ) -> Result<String> {
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args([
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = [
                 "new-window",
                 "-Pd",
                 "-t",
@@ -184,25 +191,23 @@ impl<R: Runner> TmuxClient<R> {
                 "-c",
                 path,
                 "-F",
-                "#{window_id}",
-            ]);
-            cmd
-        }))
+                "#{window_id}"
+            ]
+        ))
     }
 
     pub(crate) fn get_current_window(&self, session_name: &str) -> Result<String> {
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["display-message", "-t", session_name, "-p", "#I"]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["display-message", "-t", session_name, "-p", "#I"]
+        ))
     }
 
     pub(crate) fn split_window(&self, target: &Target, path: &str) -> Result<String> {
         let target_str = target.to_string();
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args([
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = [
                 "split-window",
                 "-t",
                 &target_str,
@@ -210,19 +215,17 @@ impl<R: Runner> TmuxClient<R> {
                 path,
                 "-P",
                 "-F",
-                "#{pane_id}",
-            ]);
-            cmd
-        }))
+                "#{pane_id}"
+            ]
+        ))
     }
 
     pub(crate) fn get_current_pane(&self, target: &Target) -> Result<String> {
         let target_str = target.to_string();
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["display-message", "-t", &target_str, "-p", "#P"]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["display-message", "-t", &target_str, "-p", "#P"]
+        ))
     }
 
     pub(crate) fn setenv(&self, target: &Target, name: &str, value: &str) {
@@ -231,20 +234,18 @@ impl<R: Runner> TmuxClient<R> {
             .borrow_mut()
             .entry(target.clone())
             .or_default()
-            .push_back(Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args(["set-environment", "-t", &target_str, name, value]);
-                cmd
-            }))
+            .push_back(tmux_cmd!(
+                self.socket.as_deref(),
+                args = ["set-environment", "-t", &target_str, name, value]
+            ))
     }
 
     pub(crate) fn getenv(&self, target: &Target, name: &str) -> Result<String> {
         let target_str = target.to_string();
-        let output: String = self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["show-environment", "-t", &target_str, name]);
-            cmd
-        }))?;
+        let output: String = self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["show-environment", "-t", &target_str, name]
+        ))?;
         output
             .trim()
             .split_once('=')
@@ -284,11 +285,10 @@ impl<R: Runner> TmuxClient<R> {
             .borrow_mut()
             .entry(target.clone())
             .or_default()
-            .push_back(Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args(["resize-pane", "-Z", "-t", &target_str]);
-                cmd
-            }))
+            .push_back(tmux_cmd!(
+                self.socket.as_deref(),
+                args = ["resize-pane", "-Z", "-t", &target_str]
+            ))
     }
 
     pub(crate) fn focus_pane(&self, target: &Target) {
@@ -297,11 +297,10 @@ impl<R: Runner> TmuxClient<R> {
             .borrow_mut()
             .entry(target.clone())
             .or_default()
-            .push_back(Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args(["select-pane", "-Z", "-t", &target_str]);
-                cmd
-            }))
+            .push_back(tmux_cmd!(
+                self.socket.as_deref(),
+                args = ["select-pane", "-Z", "-t", &target_str]
+            ))
     }
 
     pub(crate) fn flush_commands(&self) {
@@ -336,11 +335,10 @@ impl<R: Runner> TmuxClient<R> {
 
     pub(crate) fn select_layout(&self, target: &Target, layout: &str) -> Result<()> {
         let target_str = target.to_string();
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["select-layout", "-t", &target_str, layout]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["select-layout", "-t", &target_str, layout]
+        ))
     }
 
     pub(crate) fn select_custom_layout(&self, target: &Target, layout: &str) -> Result<()> {
@@ -361,15 +359,14 @@ impl<R: Runner> TmuxClient<R> {
     pub(crate) fn get_dimensions(&self) -> Result<Dimensions> {
         let res: String = if self.is_inside_session() {
             log::debug!("Inside session, using tmux dimensions.");
-            self.cmd_runner.run(&Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args([
+            self.cmd_runner.run(&tmux_cmd!(
+                self.socket.as_deref(),
+                args = [
                     "display-message",
                     "-p",
-                    "width: #{window_width}\nheight: #{window_height}",
-                ]);
-                cmd
-            }))?
+                    "width: #{window_width}\nheight: #{window_height}"
+                ]
+            ))?
         } else {
             log::debug!("Outside session, using terminal dimensions.");
             let (width, height) = size().into_diagnostic()?;
@@ -382,11 +379,10 @@ impl<R: Runner> TmuxClient<R> {
 
     pub(crate) fn list_sessions(&self) -> Result<Vec<(String, bool)>> {
         self.cmd_runner
-            .run(&Type::Basic({
-                let mut cmd = self.tmux_cmd();
-                cmd.args(["ls", "-F", "#{session_name}|#{session_attached}"]);
-                cmd
-            }))
+            .run(&tmux_cmd!(
+                self.socket.as_deref(),
+                args = ["ls", "-F", "#{session_name}|#{session_attached}"]
+            ))
             .map(|res: String| {
                 res.lines()
                     .filter_map(|line| {
@@ -405,11 +401,10 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn get_base_idx(&self) -> Result<usize> {
-        let res: String = self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["show-options", "-g", "base-index"]);
-            cmd
-        }))?;
+        let res: String = self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["show-options", "-g", "base-index"]
+        ))?;
         res.split_whitespace()
             .last()
             .unwrap_or("0")
@@ -419,11 +414,10 @@ impl<R: Runner> TmuxClient<R> {
 
     pub(crate) fn set_pane_style(&self, target: &Target, style: &str) -> Result<()> {
         let target_str = target.to_string();
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["select-pane", "-t", &target_str, "-P", style]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["select-pane", "-t", &target_str, "-P", style]
+        ))
     }
 
     pub(crate) fn bind_key(&self, key: &str, cmd: &str) -> Result<()> {
@@ -439,36 +433,32 @@ impl<R: Runner> TmuxClient<R> {
             }
         };
 
-        self.cmd_runner.run(&Type::Basic({
-            let mut c = self.tmux_cmd();
-            c.args(["bind-key", "-T", table, key, cmd]);
-            c
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["bind-key", "-T", table, key, cmd]
+        ))
     }
 
     pub(crate) fn session_name(&self) -> Result<String> {
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["display-message", "-p", "#S"]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["display-message", "-p", "#S"]
+        ))
     }
 
     pub(crate) fn session_layout(&self) -> Result<String> {
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["list-windows", "-F", "\"#{window_name} #{window_layout}\""]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["list-windows", "-F", "\"#{window_name} #{window_layout}\""]
+        ))
     }
 
     pub(crate) fn rename_window(&self, target: &Target, name: &str) -> Result<()> {
         let target_str = target.to_string();
-        self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["rename-window", "-t", &target_str, name]);
-            cmd
-        }))
+        self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["rename-window", "-t", &target_str, name]
+        ))
     }
 
     pub(crate) fn session_start_path(&self) -> Result<String> {
@@ -537,11 +527,10 @@ impl<R: Runner> TmuxClient<R> {
     }
 
     pub(crate) fn pane_paths(&self) -> Result<HashMap<String, String>> {
-        let output: String = self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["list-panes", "-s", "-F", "#{pane_id} #{pane_current_path}"]);
-            cmd
-        }))?;
+        let output: String = self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["list-panes", "-s", "-F", "#{pane_id} #{pane_current_path}"]
+        ))?;
 
         let pane_map = output
             .lines()
@@ -563,11 +552,10 @@ impl<R: Runner> TmuxClient<R> {
     pub(crate) fn pane_command(&self) -> Result<HashMap<String, String>> {
         let current_pid = process::id().to_string();
 
-        let output: String = self.cmd_runner.run(&Type::Basic({
-            let mut cmd = self.tmux_cmd();
-            cmd.args(["list-panes", "-s", "-F", "#{pane_id} #{pane_pid}"]);
-            cmd
-        }))?;
+        let output: String = self.cmd_runner.run(&tmux_cmd!(
+            self.socket.as_deref(),
+            args = ["list-panes", "-s", "-F", "#{pane_id} #{pane_pid}"]
+        ))?;
 
         let mut pane_map: HashMap<String, String> = HashMap::new();
 

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -69,6 +69,25 @@ impl<R: Runner> Tmux<R> {
         }
     }
 
+    pub(crate) fn picker_popup_command(&self) -> String {
+        let mut command = String::from("laio start --show-picker");
+        if let Some(socket) = self.client.socket() {
+            command.push_str(" --tmux-socket \"");
+            for ch in socket.chars() {
+                match ch {
+                    '\\' | '"' | '$' | '`' => {
+                        command.push('\\');
+                        command.push(ch);
+                    }
+                    _ => command.push(ch),
+                }
+            }
+            command.push('"');
+        }
+
+        format!("display-popup -w 50 -h 16 -E '{command}'")
+    }
+
     fn process_windows(
         &self,
         session: &Session,
@@ -423,10 +442,8 @@ impl<R: Runner> Multiplexer for Tmux<R> {
 
         self.process_windows(session, &dimensions, skip_cmds)?;
 
-        self.client.bind_key(
-            "prefix M-l",
-            "display-popup -w 50 -h 16 -E 'laio start --show-picker'",
-        )?;
+        self.client
+            .bind_key("prefix M-l", &self.picker_popup_command())?;
 
         let is_inside_session = self.client.is_inside_session();
 

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use miette::{bail, Result};
+use miette::{Result, bail};
 
 use crate::{
     app::manager::session::manager::LAIO_CONFIG,
@@ -25,7 +25,7 @@ fn first_pane_path(window: &Window, window_path: &str) -> String {
     }
 }
 
-use super::{client::TmuxClient, Dimensions, Target};
+use super::{Dimensions, Target, client::TmuxClient};
 
 struct LayoutInfo<'a> {
     dimensions: &'a Dimensions,
@@ -52,15 +52,20 @@ pub(crate) struct Tmux<R: Runner = ShellRunner> {
 }
 
 impl Tmux {
-    pub fn new() -> Self {
-        Self::new_with_runner(ShellRunner::new())
+    pub fn new_with_socket(socket: Option<String>) -> Self {
+        Self::new_with_runner_and_socket(ShellRunner::new(), socket)
     }
 }
 
 impl<R: Runner> Tmux<R> {
+    #[cfg(test)]
     pub fn new_with_runner(runner: R) -> Self {
+        Self::new_with_runner_and_socket(runner, None)
+    }
+
+    pub fn new_with_runner_and_socket(runner: R, socket: Option<String>) -> Self {
         Self {
-            client: TmuxClient::new(Arc::new(runner)),
+            client: TmuxClient::new_with_socket(Arc::new(runner), socket),
         }
     }
 
@@ -69,6 +74,17 @@ impl<R: Runner> Tmux<R> {
         session: &Session,
         dimensions: &Dimensions,
         skip_cmds: bool,
+    ) -> Result<()> {
+        self.process_windows_for(&session.name, session, dimensions, skip_cmds, false)
+    }
+
+    fn process_windows_for(
+        &self,
+        name: &str,
+        session: &Session,
+        dimensions: &Dimensions,
+        skip_cmds: bool,
+        force_new_windows: bool,
     ) -> Result<()> {
         let base_idx = self.client.get_base_idx()?;
         log::trace!("base-index: {base_idx}");
@@ -82,14 +98,14 @@ impl<R: Runner> Tmux<R> {
 
                 let window_path = window.effective_path(&session.path);
 
-                let window_id = if idx == base_idx {
-                    let id = self.client.get_current_window(&session.name)?;
+                let window_id = if !force_new_windows && idx == base_idx {
+                    let id = self.client.get_current_window(name)?;
                     self.client
-                        .rename_window(&tmux_target!(&session.name, &id), &window.name)?;
+                        .rename_window(&tmux_target!(name, &id), &window.name)?;
                     id
                 } else {
                     let path = first_pane_path(window, &window_path);
-                    self.client.new_window(&session.name, &window.name, &path)?
+                    self.client.new_window(name, &window.name, &path)?
                 };
                 log::trace!("window-id: {window_id}");
 
@@ -98,10 +114,10 @@ impl<R: Runner> Tmux<R> {
                 }
 
                 self.client.select_custom_layout(
-                    &tmux_target!(&session.name, &window_id),
+                    &tmux_target!(name, &window_id),
                     &self.generate_layout(
                         &LayoutMeta {
-                            name: session.name.as_str(),
+                            name,
                             id: window_id.as_str(),
                             path: window_path.as_str(),
                         },
@@ -538,7 +554,7 @@ impl<R: Runner> Multiplexer for Tmux<R> {
     }
 
     fn get_session_variables(&self, name: &str) -> Result<Option<Vec<String>>> {
-        use crate::app::manager::session::manager::{decode_variables, LAIO_VARS};
+        use crate::app::manager::session::manager::{LAIO_VARS, decode_variables};
 
         match self.client.getenv(&tmux_target!(name), LAIO_VARS) {
             Ok(encoded) => {

--- a/src/muxer/tmux/test.rs
+++ b/src/muxer/tmux/test.rs
@@ -618,3 +618,18 @@ fn client_socket_prepended_to_tmux_commands() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn mux_picker_popup_command_includes_socket() {
+    let runner = RunnerMock {
+        cmd_unit: MockCmdUnitMock::new(),
+        cmd_string: MockCmdStringMock::new(),
+        cmd_bool: MockCmdBoolMock::new(),
+    };
+
+    let tmux = Tmux::new_with_runner_and_socket(runner, Some(TEST_SOCKET.to_string()));
+
+    assert_eq!(
+        tmux.picker_popup_command(),
+        "display-popup -w 50 -h 16 -E 'laio start --show-picker --tmux-socket \"/tmp/swm-test.sock\"'"
+    );
+}

--- a/src/muxer/tmux/test.rs
+++ b/src/muxer/tmux/test.rs
@@ -1,13 +1,13 @@
 use crate::{
     common::cmd::{
-        test::{MockCmdBoolMock, MockCmdStringMock, MockCmdUnitMock, RunnerMock},
         Type,
+        test::{MockCmdBoolMock, MockCmdStringMock, MockCmdUnitMock, RunnerMock},
     },
     tmux_target,
 };
 use crate::{
     common::{config::Session, muxer::multiplexer::Multiplexer, session_info::SessionStatus},
-    muxer::{tmux::Target, Tmux},
+    muxer::{Tmux, tmux::Target},
 };
 use lazy_static::lazy_static;
 use miette::Result;
@@ -15,12 +15,14 @@ use serde_valid::yaml::FromYamlStr;
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
 use super::client::TmuxClient;
+
+const TEST_SOCKET: &str = "/tmp/swm-test.sock";
 
 #[test]
 fn client_create_session() -> Result<()> {
@@ -591,3 +593,28 @@ fn mux_list_sessions() -> Result<()> {
 
     Ok(())
 }
+
+// socket flag appears in tmux commands when TmuxClient is configured with a socket.
+#[test]
+fn client_socket_prepended_to_tmux_commands() -> Result<()> {
+    let mut cmd_bool = MockCmdBoolMock::new();
+    let cmd_string = MockCmdStringMock::new();
+    let cmd_unit = MockCmdUnitMock::new();
+
+    cmd_bool
+        .expect_run()
+        .times(1)
+        .withf(|cmd| cmd.to_string().contains("-S") && cmd.to_string().contains(TEST_SOCKET))
+        .returning(|_| Ok(false));
+
+    let runner = RunnerMock {
+        cmd_unit,
+        cmd_string,
+        cmd_bool,
+    };
+
+    let client = TmuxClient::new_with_socket(Arc::new(runner), Some(TEST_SOCKET.to_string()));
+    let _ = client.session_exists("any-session");
+    Ok(())
+}
+


### PR DESCRIPTION
## Problem

When laio is used as a tmux plugin — where tmux runs on a non-default socket — every laio command was silently targeting the default tmux server. This caused laio to operate on the wrong server or fail outright.

## Solution

Add a global `--tmux-socket <path>` flag (and `LAIO_TMUX_SOCKET` env var fallback) that pins all tmux operations to the specified server. The flag lives on the top-level CLI struct so it applies consistently to every subcommand without needing to be threaded through each one manually.

- `TmuxClient` stores the socket and prepends `-S <path>` to every tmux invocation
- `start`, `stop`, `list`, `config list`, `session list`, and `session yaml` all honor the resolved socket
- The `M-l` picker popup binding embeds `--tmux-socket` in the reopened `laio start --show-picker` command so the picker re-opens against the same server
- Passing `--tmux-socket` with Zellij emits a warning and is ignored (flag is tmux-specific)

## Test plan

- [x] `cargo test --quiet` passes
- [x] `laio --tmux-socket /tmp/my.sock start <session>` targets the correct server (`tmux -S /tmp/my.sock ls` confirms)
- [x] `LAIO_TMUX_SOCKET=/tmp/my.sock laio start <session>` works identically
- [x] `--tmux-socket` takes priority over `LAIO_TMUX_SOCKET`
- [ ] Pressing `M-l` inside a session started with `--tmux-socket` reopens the picker on the same server