### PR TITLE
feat(tmux): add window-level focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ env:
 # Window and pane layout
 windows:
   - name: editor
+    focus: true  # active window after session creation
     panes:
       - name: nvim
         commands:
@@ -213,7 +214,8 @@ windows:
 **Key features:**
 - `flex`: Proportional sizing (e.g., `flex: 2` = twice the size of `flex: 1`)
 - `flex_direction`: `row` (vertical split, side-by-side) or `column` (horizontal split, stacked)
-- `focus`: Pin initial cursor position
+- `focus` (window): Active window after session creation; defaults to first window if none set
+- `focus` (pane): Pin initial cursor position within a window
 - `zoom`: Start pane in zoomed state
 - `commands`: Sequential command execution
 - `script`: Inline script blocks

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ windows:
 **Key features:**
 - `flex`: Proportional sizing (e.g., `flex: 2` = twice the size of `flex: 1`)
 - `flex_direction`: `row` (vertical split, side-by-side) or `column` (horizontal split, stacked)
-- `focus` (window): Active window after session creation; defaults to first window if none set
+- `focus` (window): Active window after session creation
 - `focus` (pane): Pin initial cursor position within a window
 - `zoom`: Start pane in zoomed state
 - `commands`: Sequential command execution

--- a/docs/content/docs/configuration/yaml-reference.md
+++ b/docs/content/docs/configuration/yaml-reference.md
@@ -405,7 +405,7 @@ done
 
 **`focus`** (boolean)
 - Set to `true` to make this window active after session creation
-- Only one window should have `focus: true`; if none is set, the first window is selected
+- Only one window should have `focus: true`; if none is set, tmux default selection applies
 - Default: `false`
 - Example:
   ```yaml

--- a/docs/content/docs/configuration/yaml-reference.md
+++ b/docs/content/docs/configuration/yaml-reference.md
@@ -403,6 +403,18 @@ done
 - See [Pane-Level Fields](#pane-level-fields)
 - If omitted, the window gets a single default pane whose working directory is the window's `path` (or the session `path` if `path` isn't set) — useful when all you want is a window at a specific directory
 
+**`focus`** (boolean)
+- Set to `true` to make this window active after session creation
+- Only one window should have `focus: true`; if none is set, the first window is selected
+- Default: `false`
+- Example:
+  ```yaml
+  windows:
+    - name: editor
+      focus: true
+    - name: terminal
+  ```
+
 **`flex_direction`** (string: `"row"` or `"column"`)
 - Layout direction for panes
 - `"row"`: vertical split (panes side-by-side, left/right)

--- a/src/common/config/model/session.rs
+++ b/src/common/config/model/session.rs
@@ -66,6 +66,7 @@ impl Session {
 
         session.validate_exclusive_pane_property(|p| p.zoom, "zoom enabled")?;
         session.validate_exclusive_pane_property(|p| p.focus, "focus")?;
+        session.validate_window_focus()?;
 
         let session_path = if session.path.starts_with('.') {
             let parent = config
@@ -98,6 +99,13 @@ impl Session {
                     property_name
                 );
             }
+        }
+        Ok(())
+    }
+
+    fn validate_window_focus(&self) -> Result<()> {
+        if self.windows.iter().filter(|w| w.focus).count() > 1 {
+            bail!("Session '{}' has more than one window with focus enabled", self.name);
         }
         Ok(())
     }

--- a/src/common/config/model/window.rs
+++ b/src/common/config/model/window.rs
@@ -20,6 +20,8 @@ pub(crate) struct Window {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[validate]
     pub(crate) panes: Vec<Pane>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) focus: bool,
 }
 
 impl Window {

--- a/src/muxer/tmux/client.rs
+++ b/src/muxer/tmux/client.rs
@@ -405,6 +405,13 @@ impl<R: Runner> TmuxClient<R> {
         ))
     }
 
+    pub(crate) fn select_window(&self, target: &str) -> Result<()> {
+        self.cmd_runner.run(&cmd_basic!(
+            "tmux",
+            args = ["select-window", "-t", target]
+        ))
+    }
+
     pub(crate) fn session_start_path(&self) -> Result<String> {
         let pane_map: HashMap<String, String> = self.pane_paths()?;
         let pane_paths: Vec<PathBuf> = pane_map.values().map(PathBuf::from).collect();

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use miette::{bail, Result};
+use miette::{Result, bail};
 
 use crate::{
     app::manager::session::manager::LAIO_CONFIG,
@@ -25,7 +25,7 @@ fn first_pane_path(window: &Window, window_path: &str) -> String {
     }
 }
 
-use super::{client::TmuxClient, Dimensions, Target};
+use super::{Dimensions, Target, client::TmuxClient};
 
 struct LayoutInfo<'a> {
     dimensions: &'a Dimensions,
@@ -407,6 +407,17 @@ impl<R: Runner> Multiplexer for Tmux<R> {
 
         self.process_windows(session, &dimensions, skip_cmds)?;
 
+        // Select the window marked focus:true, falling back to the first window.
+        let focus_window = session
+            .windows
+            .iter()
+            .find(|w| w.focus)
+            .or_else(|| session.windows.first());
+        if let Some(window) = focus_window {
+            let target = format!("{}:{}", session.name, window.name);
+            self.client.select_window(&target)?;
+        }
+
         self.client.bind_key(
             "prefix M-l",
             "display-popup -w 50 -h 16 -E 'laio start --show-picker'",
@@ -538,7 +549,7 @@ impl<R: Runner> Multiplexer for Tmux<R> {
     }
 
     fn get_session_variables(&self, name: &str) -> Result<Option<Vec<String>>> {
-        use crate::app::manager::session::manager::{decode_variables, LAIO_VARS};
+        use crate::app::manager::session::manager::{LAIO_VARS, decode_variables};
 
         match self.client.getenv(&tmux_target!(name), LAIO_VARS) {
             Ok(encoded) => {

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -407,13 +407,7 @@ impl<R: Runner> Multiplexer for Tmux<R> {
 
         self.process_windows(session, &dimensions, skip_cmds)?;
 
-        // Select the window marked focus:true, falling back to the first window.
-        let focus_window = session
-            .windows
-            .iter()
-            .find(|w| w.focus)
-            .or_else(|| session.windows.first());
-        if let Some(window) = focus_window {
+        if let Some(window) = session.windows.iter().find(|w| w.focus) {
             let target = format!("{}:{}", session.name, window.name);
             self.client.select_window(&target)?;
         }

--- a/src/muxer/tmux/parser.rs
+++ b/src/muxer/tmux/parser.rs
@@ -71,6 +71,7 @@ impl Window {
             path: None,
             flex_direction: pane_flex_direction.clone().unwrap_or_default(),
             panes: Pane::from_tokens(&token.children, pane_flex_direction.unwrap_or_default()),
+            focus: false,
         }
     }
 }

--- a/src/muxer/tmux/test.rs
+++ b/src/muxer/tmux/test.rs
@@ -386,12 +386,6 @@ fn mux_start_session() {
     cmd_unit
         .expect_run()
         .times(1)
-        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux select-window -t valid:code"))
-        .returning(|_| Ok(()));
-
-    cmd_unit
-        .expect_run()
-        .times(1)
         .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux bind-key -T prefix M-l display-popup -w 50 -h 16 -E 'laio start --show-picker'"))
         .returning(|_| Ok(()));
 

--- a/src/muxer/tmux/test.rs
+++ b/src/muxer/tmux/test.rs
@@ -386,6 +386,12 @@ fn mux_start_session() {
     cmd_unit
         .expect_run()
         .times(1)
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux select-window -t valid:code"))
+        .returning(|_| Ok(()));
+
+    cmd_unit
+        .expect_run()
+        .times(1)
         .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux bind-key -T prefix M-l display-popup -w 50 -h 16 -E 'laio start --show-picker'"))
         .returning(|_| Ok(()));
 
@@ -590,4 +596,86 @@ fn mux_list_sessions() -> Result<()> {
     assert_eq!(sessions[2].status, SessionStatus::Attached);
 
     Ok(())
+}
+
+#[test]
+fn mux_start_session_window_focus() {
+    // Two windows, second has focus:true — select-window must target "second".
+    let yaml = "
+name: test
+path: /tmp
+windows:
+  - name: first
+  - name: second
+    focus: true
+";
+    let session = serde_valid::yaml::FromYamlStr::from_yaml_str(yaml).unwrap();
+
+    let mut cmd_unit = MockCmdUnitMock::new();
+    let mut cmd_string = MockCmdStringMock::new();
+    let mut cmd_bool = MockCmdBoolMock::new();
+
+    cmd_bool
+        .expect_run()
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux has-session -t test"))
+        .times(1)
+        .returning(|_| Ok(false));
+
+    cmd_string
+        .expect_run()
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "printenv TMUX"))
+        .times(2)
+        .returning(|_| Ok("something".to_string()));
+
+    cmd_string
+        .expect_run()
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string().contains("window_width")))
+        .times(1)
+        .returning(|_| Ok("width: 160\nheight: 90".to_string()));
+
+    cmd_unit
+        .expect_run()
+        .times(1)
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string().starts_with("tmux new-session -d -s test")))
+        .returning(|_| Ok(()));
+
+    cmd_string
+        .expect_run()
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux show-options -g base-index"))
+        .times(1)
+        .returning(|_| Ok("base-index 1".to_string()));
+
+    cmd_string
+        .expect_run()
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux display-message -t test -p #I"))
+        .times(1)
+        .returning(|_| Ok("@1".to_string()));
+
+    cmd_unit
+        .expect_run()
+        .times(1)
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux rename-window -t test:@1 first"))
+        .returning(|_| Ok(()));
+
+    cmd_string
+        .expect_run()
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string().contains("new-window") && cmd.to_string().contains("second")))
+        .times(1)
+        .returning(|_| Ok("@2".to_string()));
+
+    cmd_unit
+        .expect_run()
+        .times(1)
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string() == "tmux select-window -t test:second"))
+        .returning(|_| Ok(()));
+
+    cmd_unit
+        .expect_run()
+        .times(1)
+        .withf(|cmd| matches!(cmd, Type::Basic(_) if cmd.to_string().contains("bind-key")))
+        .returning(|_| Ok(()));
+
+    let runner = RunnerMock { cmd_unit, cmd_string, cmd_bool };
+    let tmux = Tmux::new_with_runner(runner);
+    assert!(tmux.start(&session, &[], true, true).is_ok());
 }

--- a/src/muxer/zellij/model.rs
+++ b/src/muxer/zellij/model.rs
@@ -141,6 +141,7 @@ impl Window {
                     path,
                     flex_direction,
                     panes,
+                    focus: false,
                 }
             })
             .collect()


### PR DESCRIPTION
Fixes #364

- add `focus: true` field to window config
- call `select-window` after session setup to activate the focused window (falls back to first window if none marked)