### PR TITLE
fix(flake): deduplicate flake-parts inputs in rustnix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "base-nixpkgs": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": [
+          "flake-parts"
+        ],
         "stable": "stable",
         "unstable": "unstable"
       },
@@ -46,24 +48,6 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
         "nixpkgs-lib": [
           "nixpkgs"
         ]
@@ -82,25 +66,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "base-nixpkgs": "base-nixpkgs",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "nixpkgs": [
           "base-nixpkgs",
           "unstable"

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,10 @@
 {
   description = "Simple flexbox-inspired layout manager for tmux.";
   inputs = {
-    base-nixpkgs.url = "github:ck3mp3r/flakes?dir=base-nixpkgs";
+    base-nixpkgs = {
+      url = "github:ck3mp3r/flakes?dir=base-nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
     nixpkgs.follows = "base-nixpkgs/unstable";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -9,9 +12,11 @@
     };
     rustnix = {
       url = "github:ck3mp3r/flakes?dir=rustnix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.base-nixpkgs.follows = "base-nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
+      inputs = {
+        base-nixpkgs.follows = "base-nixpkgs";
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+      };
     };
   };
 


### PR DESCRIPTION
deduplicate `flake-parts` inputs by adding `follows` for `rustnix` and its transitive `base-nixpkgs` input
