### PR TITLE
fix: remove redundant borrows in format/debug/trace macros

### DIFF
--- a/src/app/cli/command_line.rs
+++ b/src/app/cli/command_line.rs
@@ -111,7 +111,7 @@ impl Cli {
                 .into_diagnostic()
                 .wrap_err(format!(
                     "Could not access config path '{}'",
-                    &self.config_dir
+                    self.config_dir
                 ))?;
         }
         let res = match &self.commands {

--- a/src/app/manager/config/manager.rs
+++ b/src/app/manager/config/manager.rs
@@ -140,7 +140,7 @@ impl<R: Runner> ConfigManager<R> {
             .run(&cmd_forget!("ln", args = ["-s", &source, &destination]))
             .wrap_err(format!(
                 "Failed to link '{}' to '{}'",
-                &source.to_string_lossy(),
+                source.to_string_lossy(),
                 destination
             ))
     }
@@ -152,7 +152,7 @@ impl<R: Runner> ConfigManager<R> {
         variables: &[String],
     ) -> Result<()> {
         let config = match name {
-            Some(name) => format!("{}/{}.yaml", &self.config_path, name),
+            Some(name) => format!("{}/{}.yaml", self.config_path, name),
             None => {
                 let file_path = file.unwrap_or(".laio.yaml");
                 PathBuf::from(&file_path)
@@ -177,10 +177,10 @@ impl<R: Runner> ConfigManager<R> {
                 return Ok(());
             }
         }
-        let file = format!("{}/{}.yaml", &self.config_path, name.sanitize());
+        let file = format!("{}/{}.yaml", self.config_path, name.sanitize());
         fs::remove_file(&file)
             .into_diagnostic()
-            .wrap_err(format!("Failed to delete '{}'", &file))?;
+            .wrap_err(format!("Failed to delete '{}'", file))?;
         Ok(())
     }
 
@@ -189,7 +189,7 @@ impl<R: Runner> ConfigManager<R> {
             .into_diagnostic()
             .wrap_err(format!(
                 "Failed to list config entries in '{}'",
-                &self.config_path
+                self.config_path
             ))?
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.path())

--- a/src/app/manager/session/manager.rs
+++ b/src/app/manager/session/manager.rs
@@ -108,7 +108,7 @@ impl SessionManager {
         name: &str,
         variables: &[String],
     ) -> Result<(PathBuf, Vec<String>)> {
-        let config_file = format!("{}/{}.yaml", &self.config_path, name.sanitize());
+        let config_file = format!("{}/{}.yaml", self.config_path, name.sanitize());
         let config_path = to_absolute_path(&config_file)
             .wrap_err(format!("Could not get absolute path for '{config_file}'"))?;
 
@@ -320,7 +320,7 @@ impl SessionManager {
                 .into_diagnostic()
                 .wrap_err(format!(
                     "Failed to list config entries in '{}'",
-                    &config_path
+                    config_path
                 ))?
                 .filter_map(|entry| entry.ok())
                 .map(|entry| entry.path())
@@ -356,7 +356,7 @@ impl SessionManager {
             match selected {
                 Ok(info) => {
                     let path =
-                        PathBuf::from(format!("{}/{}.yaml", &config_path, info.name.sanitize()));
+                        PathBuf::from(format!("{}/{}.yaml", config_path, info.name.sanitize()));
                     // Return session name if it's active
                     let active_session = if info.is_active() {
                         Some(info.name.clone())

--- a/src/common/cmd/shell_runner.rs
+++ b/src/common/cmd/shell_runner.rs
@@ -78,7 +78,7 @@ impl ShellRunner {
             println!("{PROMPT_CHAR} {oc:?}");
         }
 
-        log::debug!("Running: {}", &cmd.to_string());
+        log::debug!("Running: {}", cmd);
 
         let mut command = Command::new(oc.get_program());
         command.args(oc.get_args()).stderr(Stdio::piped());

--- a/src/common/config/model/session.rs
+++ b/src/common/config/model/session.rs
@@ -43,7 +43,7 @@ impl Session {
             noyalib::compat::serde_yaml::from_str(&rendered_config).map_err(|e| {
                 miette::Report::msg(format!(
                     "Failed to parse config: {:?}\n\n{}",
-                    &config, e
+                    config, e
                 ))
             })?;
 

--- a/src/muxer/tmux/client.rs
+++ b/src/muxer/tmux/client.rs
@@ -321,7 +321,7 @@ impl<R: Runner> TmuxClient<R> {
             format!("width: {width}\nheight: {height}")
         };
 
-        log::trace!("{}", &res);
+        log::trace!("{}", res);
         from_str(&res).into_diagnostic()
     }
 

--- a/src/muxer/tmux/mux.rs
+++ b/src/muxer/tmux/mux.rs
@@ -480,7 +480,7 @@ impl<R: Runner> Multiplexer for Tmux<R> {
             bail!("Session {} does not exist!", &name);
         }
         if !self.is_laio_session(&name)? {
-            log::debug!("Not a laio session: {}", &name);
+            log::debug!("Not a laio session: {}", name);
             return Ok(());
         }
 

--- a/src/muxer/zellij/mux.rs
+++ b/src/muxer/zellij/mux.rs
@@ -143,7 +143,7 @@ impl<R: Runner> Multiplexer for Zellij<R> {
             bail!("Session {} does not exist!", &name);
         }
         if !self.is_laio_session(&name)? {
-            log::debug!("Not a laio session: {}", &name);
+            log::debug!("Not a laio session: {}", name);
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

Fixes all 14 `clippy::useless_borrows_in_formatting` errors that were blocking `cargo clippy -- -D warnings`.

## Changes

Removed redundant `&` borrows in `format!`, `debug!`, and `trace!` macro arguments across 7 files — the formatting machinery already borrows automatically:

- `src/app/cli/command_line.rs` (1 fix)
- `src/app/manager/config/manager.rs` (5 fixes)
- `src/app/manager/session/manager.rs` (3 fixes)
- `src/common/cmd/shell_runner.rs` (1 fix + removed redundant `to_string()`)
- `src/common/config/model/session.rs` (1 fix)
- `src/muxer/tmux/client.rs` (1 fix)
- `src/muxer/tmux/mux.rs` (1 fix)
- `src/muxer/zellij/mux.rs` (1 fix)

The `to_string()` removal in `shell_runner.rs` was exposed after fixing the borrow — the type implements `Display`, which `format!` uses directly.

## Verification

- `cargo clippy --package laio -- -D warnings` — clean (0 errors)
- `cargo test --package laio` — 103 passed, 0 failed, 1 ignored